### PR TITLE
Search shows & add to lists

### DIFF
--- a/components/Actors/index.js
+++ b/components/Actors/index.js
@@ -26,17 +26,17 @@ const StyledListItem = styled.li`
 
 export default function Actors({ actors }) {
   if (!actors) return <p>Loading cast...</p>;
-
   return (
     <StyledList>
       {actors?.map((actor) => {
         return (
-          <StyledListItem key={actor.cast_id}>
+          <StyledListItem key={actor?.character}>
             <Image
               src={`https://image.tmdb.org/t/p/original/${actor.profile_path}`}
               alt={actor.name}
               width={70}
               height={100}
+              key={actor.profile_path}
             />
             <StyledName key={actor.name}>{actor.name}</StyledName>
           </StyledListItem>

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -2,7 +2,8 @@ import React from "react";
 import { useRouter } from "next/router";
 import styled from "styled-components";
 import Image from "next/image";
-
+import { useContext } from "react";
+import { MediaContext } from "../../pages/_app";
 const StyledSection = styled.section``;
 
 const StyledSectionRadioButtons = styled.section`
@@ -52,12 +53,15 @@ const StyledButton = styled.button`
 `;
 
 export default function Form({ onSubmit }) {
+  const { handleMediaTypeChange, mediaTypeMovies } = useContext(MediaContext);
   const router = useRouter();
 
   function handleOnSubmit(event) {
     onSubmit(event);
     router.push("/search-results");
   }
+
+  console.log(mediaTypeMovies);
 
   return (
     <>
@@ -84,14 +88,25 @@ export default function Form({ onSubmit }) {
               <input
                 type="radio"
                 id="movies"
-                name="medium"
+                name="media-type"
                 value="movies"
-                checked
+                onChange={() => {
+                  handleMediaTypeChange(true);
+                }}
+                defaultChecked
               />
             </StyledSectionRadio>
             <StyledSectionRadio>
               <label htmlFor="shows">Shows:</label>
-              <input type="radio" id="shows" name="medium" value="shows" />
+              <input
+                type="radio"
+                id="shows"
+                name="media-type"
+                value="shows"
+                onChange={() => {
+                  handleMediaTypeChange(false);
+                }}
+              />
             </StyledSectionRadio>
           </StyledSectionRadioButtons>
         </StyledForm>

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -65,8 +65,6 @@ export default function Form({ onSubmit }) {
     router.push("/search-results");
   }
 
-  console.log(mediaTypeMovies);
-
   return (
     <>
       <StyledSection>

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -97,7 +97,7 @@ export default function Form({ onSubmit }) {
                 onChange={() => {
                   handleMediaTypeChange("movie");
                 }}
-                defaultChecked
+                required
               />
             </StyledSectionRadio>
             <StyledSectionRadio>

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -5,6 +5,16 @@ import Image from "next/image";
 
 const StyledSection = styled.section``;
 
+const StyledSectionRadioButtons = styled.section`
+  margin-top: 5px;
+  display: flex;
+  gap: 10px;
+`;
+
+const StyledSectionRadio = styled.section`
+  display: flex;
+`;
+
 const StyledForm = styled.form`
   position: relative;
   display: flex;
@@ -13,6 +23,7 @@ const StyledForm = styled.form`
 `;
 
 const StyledInput = styled.input`
+  margin-top: 10px;
   padding-right: 25px;
   width: 250px;
   height: 30px;
@@ -36,7 +47,7 @@ const StyledButton = styled.button`
   position: absolute;
   background-color: transparent;
   border: none;
-  top: 6px;
+  top: 16px;
   left: 220px;
 `;
 
@@ -67,6 +78,22 @@ export default function Form({ onSubmit }) {
               height={15}
             />
           </StyledButton>
+          <StyledSectionRadioButtons>
+            <StyledSectionRadio>
+              <label htmlFor="movies">Movies:</label>
+              <input
+                type="radio"
+                id="movies"
+                name="medium"
+                value="movies"
+                checked
+              />
+            </StyledSectionRadio>
+            <StyledSectionRadio>
+              <label htmlFor="shows">Shows:</label>
+              <input type="radio" id="shows" name="medium" value="shows" />
+            </StyledSectionRadio>
+          </StyledSectionRadioButtons>
         </StyledForm>
       </StyledSection>
     </>

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -23,7 +23,7 @@ const StyledForm = styled.form`
   width: 250px;
 `;
 
-const StyledInput = styled.input`
+const StyledInputText = styled.input`
   margin-top: 10px;
   padding-right: 25px;
   width: 250px;
@@ -39,6 +39,10 @@ const StyledInput = styled.input`
     outline: 2px solid red;
     border-radius: 5px;
   }
+`;
+
+const StyledInputRadio = styled.input`
+  accent-color: black;
 `;
 
 const StyledIcon = styled(Image)`
@@ -67,13 +71,13 @@ export default function Form({ onSubmit }) {
     <>
       <StyledSection>
         <StyledForm onSubmit={handleOnSubmit}>
-          <StyledInput
+          <StyledInputText
             type="text"
             name="search"
             id="search"
             placeholder="Search..."
             required
-          ></StyledInput>
+          ></StyledInputText>
           <StyledButton>
             <StyledIcon
               src={require("/icons/search.png")}
@@ -84,27 +88,27 @@ export default function Form({ onSubmit }) {
           </StyledButton>
           <StyledSectionRadioButtons>
             <StyledSectionRadio>
-              <label htmlFor="movies">Movies:</label>
-              <input
+              <label htmlFor="movie">Movies:</label>
+              <StyledInputRadio
                 type="radio"
-                id="movies"
+                id="movie"
                 name="media-type"
-                value="movies"
+                value="movie"
                 onChange={() => {
-                  handleMediaTypeChange(true);
+                  handleMediaTypeChange("movie");
                 }}
                 defaultChecked
               />
             </StyledSectionRadio>
             <StyledSectionRadio>
-              <label htmlFor="shows">Shows:</label>
-              <input
+              <label htmlFor="tv">Shows:</label>
+              <StyledInputRadio
                 type="radio"
-                id="shows"
+                id="tv"
                 name="media-type"
-                value="shows"
+                value="tv"
                 onChange={() => {
-                  handleMediaTypeChange(false);
+                  handleMediaTypeChange("tv");
                 }}
               />
             </StyledSectionRadio>

--- a/components/Movie/index.js
+++ b/components/Movie/index.js
@@ -7,12 +7,14 @@ import getGenreFrom from "../../utils/getGenreFrom";
 import { useFetch } from "../../hooks/useFetch";
 import { DataContext } from "../../pages/_app";
 import { useContext } from "react";
-import { OverviewWrapper } from "../Styled Components/QuickOverview";
-import { OverviewPosterContainer } from "../Styled Components/QuickOverview";
-import { OverviewPoster } from "../Styled Components/QuickOverview";
-import { OverviewTextContainer } from "../Styled Components/QuickOverview";
-import { OverviewHeader } from "../Styled Components/QuickOverview";
-import { OverviewText } from "../Styled Components/QuickOverview";
+import {
+  OverviewWrapper,
+  OverviewPosterContainer,
+  OverviewPoster,
+  OverviewTextContainer,
+  OverviewHeader,
+  OverviewText,
+} from "../Styled Components/QuickOverview";
 
 export default function Movie({ movie }) {
   const { theme } = useContext(DataContext);

--- a/components/Movie/index.js
+++ b/components/Movie/index.js
@@ -7,40 +7,12 @@ import getGenreFrom from "../../utils/getGenreFrom";
 import { useFetch } from "../../hooks/useFetch";
 import { DataContext } from "../../pages/_app";
 import { useContext } from "react";
-
-const StyledDiv = styled.div`
-  height: 200px;
-  width: 120px;
-`;
-
-const StyledSection = styled.section`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 20px;
-  transition: 0.3s ease-out;
-
-  :hover {
-    transform: translateY(-10px);
-  }
-`;
-
-const StyledSectionText = styled.section`
-  width: 200px;
-  margin-left: 20px;
-  padding-left: 10px;
-`;
-
-const StyledParagraph = styled.p`
-  color: gray;
-`;
-
-const StyledImage = styled(Image)`
-  border-radius: 15px;
-`;
-
-const StyledHeader = styled.h4`
-  color: ${(props) => props.theme.fontColor};
-`;
+import { OverviewWrapper } from "../Styled Components/QuickOverview";
+import { OverviewPosterContainer } from "../Styled Components/QuickOverview";
+import { OverviewPoster } from "../Styled Components/QuickOverview";
+import { OverviewTextContainer } from "../Styled Components/QuickOverview";
+import { OverviewHeader } from "../Styled Components/QuickOverview";
+import { OverviewText } from "../Styled Components/QuickOverview";
 
 export default function Movie({ movie }) {
   const { theme } = useContext(DataContext);
@@ -67,27 +39,27 @@ export default function Movie({ movie }) {
 
   return (
     <>
-      <StyledSection>
-        <StyledDiv>
-          <StyledImage
+      <OverviewWrapper>
+        <OverviewPosterContainer>
+          <OverviewPoster
             src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
             alt={movie?.title}
             width={135}
             height={200}
           />
-        </StyledDiv>
-        <StyledSectionText>
-          <StyledHeader color={theme}>
+        </OverviewPosterContainer>
+        <OverviewTextContainer>
+          <OverviewHeader color={theme}>
             {movie?.title} - <em>{movie?.release_date?.slice(0, 4)}</em>
-          </StyledHeader>
-          <StyledParagraph>{getGenreFrom(movie)}</StyledParagraph>
+          </OverviewHeader>
+          <OverviewText>{getGenreFrom(movie)}</OverviewText>
           {runtime ? (
-            <StyledParagraph>{calculateRuntimeFrom(runtime)}</StyledParagraph>
+            <OverviewText>{calculateRuntimeFrom(runtime)}</OverviewText>
           ) : (
             <p>no data</p>
           )}
-        </StyledSectionText>
-      </StyledSection>
+        </OverviewTextContainer>
+      </OverviewWrapper>
     </>
   );
 }

--- a/components/Movie/index.js
+++ b/components/Movie/index.js
@@ -84,7 +84,7 @@ export default function Movie({ movie }) {
           {runtime ? (
             <StyledParagraph>{calculateRuntimeFrom(runtime)}</StyledParagraph>
           ) : (
-            <p>Loading...</p>
+            <p>no data</p>
           )}
         </StyledSectionText>
       </StyledSection>

--- a/components/Movie/index.js
+++ b/components/Movie/index.js
@@ -78,7 +78,7 @@ export default function Movie({ movie }) {
         </StyledDiv>
         <StyledSectionText>
           <StyledHeader color={theme}>
-            {movie?.title} - <em>{movie?.release_date.slice(0, 4)}</em>
+            {movie?.title} - <em>{movie?.release_date?.slice(0, 4)}</em>
           </StyledHeader>
           <StyledParagraph>{getGenreFrom(movie)}</StyledParagraph>
           {runtime ? (

--- a/components/MovieDetail/index.js
+++ b/components/MovieDetail/index.js
@@ -66,6 +66,7 @@ const StyledSectionQuickOverview = styled.section`
 
 const StyledMovieTitle = styled.h2`
   margin: 5px;
+  text-align: center;
 `;
 
 const StyledMovieSubtitles = styled.p`

--- a/components/MovieDetail/index.js
+++ b/components/MovieDetail/index.js
@@ -225,15 +225,15 @@ export default function MovieDetail({ movie }) {
       <section>
         <StyledSectionPoster>
           <StyledPoster
-            src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
-            alt={movie.title}
+            src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
+            alt={movie?.title}
             width={202.5}
             height={300}
           />
         </StyledSectionPoster>
       </section>
       <StyledSectionQuickOverview>
-        <StyledMovieTitle>{movie.title}</StyledMovieTitle>
+        <StyledMovieTitle>{movie?.title}</StyledMovieTitle>
         <StyledMovieSubtitles>
           {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
         </StyledMovieSubtitles>
@@ -258,7 +258,7 @@ export default function MovieDetail({ movie }) {
           ) : null}
         </StyledSectionTrailer>
         <StyledHeaderSynopsis>Synopsis:</StyledHeaderSynopsis>
-        <StyledSynopsisText>{movie.overview}</StyledSynopsisText>
+        <StyledSynopsisText>{movie?.overview}</StyledSynopsisText>
       </StyledSectionSynopsis>
 
       <Actors actors={shownActors} />

--- a/components/MovieDetail/index.js
+++ b/components/MovieDetail/index.js
@@ -1,11 +1,5 @@
 import React from "react";
-import Image from "next/image";
-import {
-  WatchlistContext,
-  WatchedContext,
-  DataContext,
-  TrendingContext,
-} from "../../pages/_app";
+import { DataContext } from "../../pages/_app";
 import getGenreFrom from "../../utils/getGenreFrom";
 import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
 import { useState, useEffect } from "react";
@@ -14,105 +8,22 @@ import PushButton from "../PushButton";
 import showWatchProviders from "../../utils/showWatchProviders";
 import Actors from "../Actors";
 import { useContext } from "react";
-import { useRouter } from "next/router";
-import styled from "styled-components";
-import ReactPlayer from "react-player";
-import getIconForTheme from "../../utils/getIconForTheme";
-
-const StyledSectionHeader = styled.section`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const StyledHeaderMovieDetails = styled.h4`
-  margin: 15px;
-  margin-top: 0;
-`;
-
-const StyledSectionButtons = styled.section`
-  display: flex;
-`;
-
-const StyledButton = styled.button`
-  padding: 10px;
-  background-color: transparent;
-  border: none;
-`;
-
-const StyledShowTrailerButton = styled.button`
-  background-color: transparent;
-  color: ${(props) => props.theme.fontColor};
-  border: none;
-  margin-bottom: 15px;
-  cursor: pointer;
-`;
-
-const StyledPoster = styled(Image)`
-  border-radius: 30px;
-`;
-
-const StyledSectionPoster = styled.section`
-  display: flex;
-  justify-content: center;
-`;
-
-const StyledSectionQuickOverview = styled.section`
-  margin: 10px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const StyledMovieTitle = styled.h2`
-  margin: 5px;
-  text-align: center;
-`;
-
-const StyledMovieSubtitles = styled.p`
-  color: grey;
-  margin: 5px;
-`;
-
-const StyledSynopsisText = styled.p`
-  color: grey;
-`;
-
-const StyledSectionSynopsis = styled.section`
-  padding-left: 15px;
-  padding-right: 15px;
-  margin-top: 15px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-`;
-
-const StyledHeaderSynopsis = styled.h4`
-  align-self: flex-start;
-  margin: 0;
-`;
-
-const StyledTrailer = styled(ReactPlayer)`
-  margin-bottom: 15px;
-  align-self: flex-start;
-`;
-
-const StyledSectionTrailer = styled.section`
-  align-self: center;
-`;
-
-const StyledSectionAvailability = styled.section`
-  padding-left: 15px;
-`;
-
-const StyledAvailabilityHeading = styled.h4`
-  margin-bottom: 5px;
-`;
-
-const StyledAvailabilityText = styled.p`
-  margin-top: 5px;
-  color: gray;
-`;
+import { DetailHeaderContainer } from "../Styled Components/DetailPage";
+import { DetailPageDescription } from "../Styled Components/DetailPage";
+import { DetailPageDescriptionText } from "../Styled Components/DetailPage";
+import { DetailPosterContainer } from "../Styled Components/DetailPage";
+import { DetailPoster } from "../Styled Components/DetailPage";
+import { DetailHeaderTitle } from "../Styled Components/DetailPage";
+import { DetailHeaderText } from "../Styled Components/DetailPage";
+import { DetailSynopsis } from "../Styled Components/DetailPage";
+import { TrailerButton } from "../Styled Components/DetailPage";
+import { TrailerContainer } from "../Styled Components/DetailPage";
+import { DetailSynopsisHeader } from "../Styled Components/DetailPage";
+import { DetailSynopsisText } from "../Styled Components/DetailPage";
+import { DetailAvailability } from "../Styled Components/DetailPage";
+import { DetailAvailabilityHeading } from "../Styled Components/DetailPage";
+import { DetailAvailabilityText } from "../Styled Components/DetailPage";
+import { Trailer } from "../Styled Components/DetailPage";
 
 export default function MovieDetail({ movie }) {
   const [runtime, setRuntime] = useState(0);
@@ -122,12 +33,8 @@ export default function MovieDetail({ movie }) {
   const [youtubeKey, setYoutubeKey] = useState("");
   const [showTrailer, setShowTrailer] = useState(false);
   const { availabilityOption, theme } = useContext(DataContext);
-  const { handleToggleWatchList, watchlist } = useContext(WatchlistContext);
-  const { watched, handleToggleWatched } = useContext(WatchedContext);
-  const { trendingMovies } = useContext(TrendingContext);
 
   const shownActors = castActors.slice(0, 4);
-  const router = useRouter();
   const trailer = youtubeKey?.results?.find(
     (videoObject) => videoObject.type === "Trailer"
   );
@@ -219,36 +126,34 @@ export default function MovieDetail({ movie }) {
   return (
     <>
       <PushButton />
-      <StyledSectionHeader>
-        <StyledHeaderMovieDetails>Movie Details</StyledHeaderMovieDetails>
-      </StyledSectionHeader>
-      <section>
-        <StyledSectionPoster>
-          <StyledPoster
-            src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
-            alt={movie?.title}
-            width={202.5}
-            height={300}
-          />
-        </StyledSectionPoster>
-      </section>
-      <StyledSectionQuickOverview>
-        <StyledMovieTitle>{movie?.title}</StyledMovieTitle>
-        <StyledMovieSubtitles>
+      <DetailPageDescription>
+        <DetailPageDescriptionText>Movie Details</DetailPageDescriptionText>
+      </DetailPageDescription>
+      <DetailPosterContainer>
+        <DetailPoster
+          src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
+          alt={movie?.title}
+          width={202.5}
+          height={300}
+        />
+      </DetailPosterContainer>
+      <DetailHeaderContainer>
+        <DetailHeaderTitle>{movie?.title}</DetailHeaderTitle>
+        <DetailHeaderText>
           {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
-        </StyledMovieSubtitles>
-        <StyledMovieSubtitles>
+        </DetailHeaderText>
+        <DetailHeaderText>
           {getGenreFrom(movie)} • {movie.release_date.slice(0, 4)} •{" "}
           {calculateRuntimeFrom(runtime)}
-        </StyledMovieSubtitles>
-      </StyledSectionQuickOverview>
-      <StyledSectionSynopsis>
-        <StyledShowTrailerButton color={theme} onClick={displayTrailer}>
+        </DetailHeaderText>
+      </DetailHeaderContainer>
+      <DetailSynopsis>
+        <TrailerButton color={theme} onClick={displayTrailer}>
           {showTrailer ? "Hide the trailer" : "Watch the trailer"}
-        </StyledShowTrailerButton>
-        <StyledSectionTrailer>
+        </TrailerButton>
+        <TrailerContainer>
           {showTrailer ? (
-            <StyledTrailer
+            <Trailer
               controls={true}
               volume={0.2}
               width={300}
@@ -256,28 +161,27 @@ export default function MovieDetail({ movie }) {
               url={`https://www.youtube.com/watch?v=${trailer.key}`}
             />
           ) : null}
-        </StyledSectionTrailer>
-        <StyledHeaderSynopsis>Synopsis:</StyledHeaderSynopsis>
-        <StyledSynopsisText>{movie?.overview}</StyledSynopsisText>
-      </StyledSectionSynopsis>
-
+        </TrailerContainer>
+        <DetailSynopsisHeader>Synopsis:</DetailSynopsisHeader>
+        <DetailSynopsisText>{movie?.overview}</DetailSynopsisText>
+      </DetailSynopsis>
       <Actors actors={shownActors} />
-      <StyledSectionAvailability>
+      <DetailAvailability>
         <h4>Availability:</h4>
         {availabilityOption === "all" && (
           <>
-            <StyledAvailabilityHeading>Flatrate</StyledAvailabilityHeading>
-            <StyledAvailabilityText>{`${showWatchProviders(
+            <DetailAvailabilityHeading>Flatrate</DetailAvailabilityHeading>
+            <DetailAvailabilityText>{`${showWatchProviders(
               streamingProviderFlatrate
-            )}`}</StyledAvailabilityText>
-            <StyledAvailabilityHeading>Renting</StyledAvailabilityHeading>
-            <StyledAvailabilityText>
+            )}`}</DetailAvailabilityText>
+            <DetailAvailabilityHeading>Renting</DetailAvailabilityHeading>
+            <DetailAvailabilityText>
               {`${showWatchProviders(streamingProviderRent)}`}
-            </StyledAvailabilityText>
-            <StyledAvailabilityHeading>Purchase </StyledAvailabilityHeading>
-            <StyledAvailabilityText>{`${showWatchProviders(
+            </DetailAvailabilityText>
+            <DetailAvailabilityHeading>Purchase </DetailAvailabilityHeading>
+            <DetailAvailabilityText>{`${showWatchProviders(
               streamingProviderBuy
-            )}`}</StyledAvailabilityText>
+            )}`}</DetailAvailabilityText>
           </>
         )}
         {availabilityOption === "flatrate" && (
@@ -290,7 +194,7 @@ export default function MovieDetail({ movie }) {
         {availabilityOption === "purchase" && (
           <p>Purchase: {`${showWatchProviders(streamingProviderBuy)}`}</p>
         )}
-      </StyledSectionAvailability>
+      </DetailAvailability>
     </>
   );
 }

--- a/components/MovieDetail/index.js
+++ b/components/MovieDetail/index.js
@@ -8,22 +8,24 @@ import PushButton from "../PushButton";
 import showWatchProviders from "../../utils/showWatchProviders";
 import Actors from "../Actors";
 import { useContext } from "react";
-import { DetailHeaderContainer } from "../Styled Components/DetailPage";
-import { DetailPageDescription } from "../Styled Components/DetailPage";
-import { DetailPageDescriptionText } from "../Styled Components/DetailPage";
-import { DetailPosterContainer } from "../Styled Components/DetailPage";
-import { DetailPoster } from "../Styled Components/DetailPage";
-import { DetailHeaderTitle } from "../Styled Components/DetailPage";
-import { DetailHeaderText } from "../Styled Components/DetailPage";
-import { DetailSynopsis } from "../Styled Components/DetailPage";
-import { TrailerButton } from "../Styled Components/DetailPage";
-import { TrailerContainer } from "../Styled Components/DetailPage";
-import { DetailSynopsisHeader } from "../Styled Components/DetailPage";
-import { DetailSynopsisText } from "../Styled Components/DetailPage";
-import { DetailAvailability } from "../Styled Components/DetailPage";
-import { DetailAvailabilityHeading } from "../Styled Components/DetailPage";
-import { DetailAvailabilityText } from "../Styled Components/DetailPage";
-import { Trailer } from "../Styled Components/DetailPage";
+import {
+  DetailHeaderContainer,
+  DetailPosterContainer,
+  DetailHeaderTitle,
+  DetailHeaderText,
+  DetailAvailability,
+  Trailer,
+  DetailAvailabilityText,
+  DetailAvailabilityHeading,
+  TrailerContainer,
+  DetailSynopsisText,
+  DetailSynopsisHeader,
+  TrailerButton,
+  DetailSynopsis,
+  DetailPoster,
+  DetailPageDescriptionText,
+  DetailPageDescription,
+} from "../Styled Components/DetailPage";
 
 export default function MovieDetail({ movie }) {
   const [runtime, setRuntime] = useState(0);

--- a/components/MovieDetailFooter/index.js
+++ b/components/MovieDetailFooter/index.js
@@ -7,14 +7,16 @@ import {
   WatchedContext,
 } from "../../pages/_app";
 import { useContext } from "react";
-import { DetailFooter } from "../Styled Components/DetailPageFooter";
-import { DetailNavBar } from "../Styled Components/DetailPageFooter";
-import { NavBarList } from "../Styled Components/DetailPageFooter";
-import { NavBarListItem } from "../Styled Components/DetailPageFooter";
-import { DetailNavBarButtonContainer } from "../Styled Components/DetailPageFooter";
-import { NavBarListButton } from "../Styled Components/DetailPageFooter";
-import { NavBarButtonIcon } from "../Styled Components/DetailPageFooter";
-import { NavBarButtonText } from "../Styled Components/DetailPageFooter";
+import {
+  DetailFooter,
+  DetailNavBar,
+  NavBarList,
+  NavBarListButton,
+  NavBarButtonIcon,
+  NavBarButtonText,
+  DetailNavBarButtonContainer,
+  NavBarListItem,
+} from "../Styled Components/DetailPageFooter";
 
 export default function MovieDetailFooter({ movie }) {
   const { theme } = useContext(DataContext);

--- a/components/MovieDetailFooter/index.js
+++ b/components/MovieDetailFooter/index.js
@@ -1,9 +1,5 @@
 import React from "react";
-import styled from "styled-components";
-import Link from "next/link";
-import Image from "next/image";
 import { useRouter } from "next/router";
-import getIconForTheme from "../../utils/getIconForTheme";
 import {
   DataContext,
   TrendingContext,
@@ -11,53 +7,14 @@ import {
   WatchedContext,
 } from "../../pages/_app";
 import { useContext } from "react";
-
-const StyledFooter = styled.footer`
-  background-color: ${(props) => props.theme.body};
-  position: fixed;
-  width: 100%;
-  height: 80px;
-  bottom: -1px;
-  border-top: 1px solid grey;
-`;
-
-const StyledNavBar = styled.nav``;
-
-const StyledList = styled.ul`
-  list-style-type: none;
-  display: flex;
-  justify-content: space-around;
-  padding-inline-start: 0;
-`;
-
-const StyledListItem = styled.li`
-  font-size: 10px;
-`;
-
-const StyledDiv = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const StyledButton = styled.button`
-  position: relative;
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-  align-items: center;
-  height: 45px;
-  width: 160px;
-  border-radius: 20px;
-  border: none;
-  background-color: ${(props) => props.color};
-`;
-
-const StyledIcon = styled(Image)``;
-
-const StyledIconText = styled.p`
-  color: white;
-`;
+import { DetailFooter } from "../Styled Components/DetailPageFooter";
+import { DetailNavBar } from "../Styled Components/DetailPageFooter";
+import { NavBarList } from "../Styled Components/DetailPageFooter";
+import { NavBarListItem } from "../Styled Components/DetailPageFooter";
+import { DetailNavBarButtonContainer } from "../Styled Components/DetailPageFooter";
+import { NavBarListButton } from "../Styled Components/DetailPageFooter";
+import { NavBarButtonIcon } from "../Styled Components/DetailPageFooter";
+import { NavBarButtonText } from "../Styled Components/DetailPageFooter";
 
 export default function MovieDetailFooter({ movie }) {
   const { theme } = useContext(DataContext);
@@ -93,12 +50,12 @@ export default function MovieDetailFooter({ movie }) {
   }
 
   return (
-    <StyledFooter color={theme}>
-      <StyledNavBar>
-        <StyledList>
-          <StyledListItem>
-            <StyledDiv>
-              <StyledButton
+    <DetailFooter color={theme}>
+      <DetailNavBar>
+        <NavBarList>
+          <NavBarListItem>
+            <DetailNavBarButtonContainer>
+              <NavBarListButton
                 color={
                   JSON.stringify(watchlist).includes(JSON.stringify(movie))
                     ? "#f97b7b"
@@ -110,31 +67,31 @@ export default function MovieDetailFooter({ movie }) {
               >
                 {JSON.stringify(watchlist).includes(JSON.stringify(movie)) ? (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"in-watchlist"}
                       src={`/in-watchlist.png`}
                       width={20}
                       height={20}
                     />{" "}
-                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                    <NavBarButtonText color={theme}>Watchlist</NavBarButtonText>
                   </>
                 ) : (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"not-in-watchlist"}
                       src={`/not-in-watchlist.png`}
                       width={20}
                       height={20}
                     />
-                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                    <NavBarButtonText color={theme}>Watchlist</NavBarButtonText>
                   </>
                 )}
-              </StyledButton>
-            </StyledDiv>
-          </StyledListItem>
-          <StyledListItem>
-            <StyledDiv>
-              <StyledButton
+              </NavBarListButton>
+            </DetailNavBarButtonContainer>
+          </NavBarListItem>
+          <NavBarListItem>
+            <DetailNavBarButtonContainer>
+              <NavBarListButton
                 color={
                   JSON.stringify(watched).includes(JSON.stringify(movie))
                     ? "#f97b7b"
@@ -146,31 +103,31 @@ export default function MovieDetailFooter({ movie }) {
               >
                 {JSON.stringify(watched).includes(JSON.stringify(movie)) ? (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"in-watched"}
                       src={`/in-watched.png`}
                       width={20}
                       height={20}
                     />
 
-                    <StyledIconText color={theme}>Watched</StyledIconText>
+                    <NavBarButtonText color={theme}>Watched</NavBarButtonText>
                   </>
                 ) : (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"not-in-watched"}
                       src={`/not-in-watched.png`}
                       width={20}
                       height={20}
                     />
-                    <StyledIconText color={theme}>Watched</StyledIconText>
+                    <NavBarButtonText color={theme}>Watched</NavBarButtonText>
                   </>
                 )}
-              </StyledButton>
-            </StyledDiv>
-          </StyledListItem>
-        </StyledList>
-      </StyledNavBar>
-    </StyledFooter>
+              </NavBarListButton>
+            </DetailNavBarButtonContainer>
+          </NavBarListItem>
+        </NavBarList>
+      </DetailNavBar>
+    </DetailFooter>
   );
 }

--- a/components/Styled Components/DetailPage/index.js
+++ b/components/Styled Components/DetailPage/index.js
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import ReactPlayer from "react-player";
+import styled from "styled-components";
+
+export const DetailPageDescription = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const DetailPageDescriptionText = styled.h4`
+  margin: 15px;
+  margin-top: 0;
+`;
+
+export const TrailerButton = styled.button`
+  background-color: transparent;
+  color: ${(props) => props.theme.fontColor};
+  border: none;
+  margin-bottom: 15px;
+  cursor: pointer;
+`;
+
+export const DetailPoster = styled(Image)`
+  border-radius: 30px;
+`;
+
+export const DetailPosterContainer = styled.section`
+  display: flex;
+  justify-content: center;
+`;
+
+export const DetailHeaderContainer = styled.section`
+  margin: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const DetailHeaderTitle = styled.h2`
+  margin: 5px;
+  text-align: center;
+`;
+
+export const DetailHeaderText = styled.p`
+  color: grey;
+  margin: 5px;
+`;
+
+export const DetailSynopsisText = styled.p`
+  color: grey;
+`;
+
+export const DetailSynopsis = styled.section`
+  padding-left: 15px;
+  padding-right: 15px;
+  margin-top: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`;
+
+export const DetailSynopsisHeader = styled.h4`
+  align-self: flex-start;
+  margin: 0;
+`;
+
+export const Trailer = styled(ReactPlayer)`
+  margin-bottom: 15px;
+  align-self: flex-start;
+`;
+
+export const TrailerContainer = styled.section`
+  align-self: center;
+`;
+
+export const DetailAvailability = styled.section`
+  padding-left: 15px;
+`;
+
+export const DetailAvailabilityHeading = styled.h4`
+  margin-bottom: 5px;
+`;
+
+export const DetailAvailabilityText = styled.p`
+  margin-top: 5px;
+  color: gray;
+`;

--- a/components/Styled Components/DetailPageFooter/index.js
+++ b/components/Styled Components/DetailPageFooter/index.js
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import styled from "styled-components";
+
+export const DetailFooter = styled.footer`
+  background-color: ${(props) => props.theme.body};
+  position: fixed;
+  width: 100%;
+  height: 80px;
+  bottom: -1px;
+  border-top: 1px solid grey;
+`;
+
+export const DetailNavBar = styled.nav``;
+
+export const NavBarList = styled.ul`
+  list-style-type: none;
+  display: flex;
+  justify-content: space-around;
+  padding-inline-start: 0;
+`;
+
+export const NavBarListItem = styled.li`
+  font-size: 10px;
+`;
+
+export const DetailNavBarButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const NavBarListButton = styled.button`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  align-items: center;
+  height: 45px;
+  width: 160px;
+  border-radius: 20px;
+  border: none;
+  background-color: ${(props) => props.color};
+`;
+
+export const NavBarButtonIcon = styled(Image)``;
+
+export const NavBarButtonText = styled.p`
+  color: white;
+`;

--- a/components/Styled Components/ListPage/index.js
+++ b/components/Styled Components/ListPage/index.js
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import styled from "styled-components";
+
+export const LinkWrapper = styled(Link)`
+  text-decoration: none;
+  color: black;
+  cursor: pointer;
+`;
+
+export const LayoutListButton = styled.button`
+  border: none;
+  background-color: transparent;
+
+  :enabled {
+    color: ${(props) => props.theme.fontColor};
+  }
+
+  :disabled {
+    color: #f97b7b;
+  }
+`;
+
+export const EmptyContentContainer = styled.section`
+  height: 550px;
+  padding-left: 15px;
+  padding-right: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+`;
+
+export const LayoutGridButton = styled.button`
+  border: none;
+  background-color: transparent;
+
+  :enabled {
+    color: ${(props) => props.theme.fontColor};
+  }
+
+  :disabled {
+    color: #f97b7b;
+  }
+`;
+
+export const ContentContainerGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  justify-items: center;
+  grid-row-gap: 5px;
+  margin-top: 15px;
+`;
+
+export const EmptyWatchedContainer = styled.section`
+  height: 550px;
+  padding-left: 15px;
+  padding-right: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ListWrapper = styled.section`
+  padding-left: 15px;
+  padding-right: 15px;
+`;
+
+export const ButtonsFlexContainer = styled.section`
+  width: 100%;
+  margin-bottom: 15px;
+`;
+
+export const ButtonsContainer = styled.section`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const ContentContainerList = styled.section`
+  margin-top: 15px;
+`;
+
+export const MediaHeader = styled.h5`
+  margin-bottom: 5px;
+`;

--- a/components/Styled Components/QuickOverview/index.js
+++ b/components/Styled Components/QuickOverview/index.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import Image from "next/image";
+
+export const OverviewPosterContainer = styled.div`
+  height: 200px;
+  width: 120px;
+`;
+
+export const OverviewWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  transition: 0.3s ease-out;
+
+  :hover {
+    transform: translateY(-10px);
+  }
+`;
+
+export const OverviewTextContainer = styled.section`
+  width: 200px;
+  margin-left: 20px;
+  padding-left: 10px;
+`;
+
+export const OverviewText = styled.p`
+  color: gray;
+`;
+
+export const OverviewPoster = styled(Image)`
+  border-radius: 15px;
+`;
+
+export const OverviewHeader = styled.h4`
+  color: ${(props) => props.theme.fontColor};
+`;

--- a/components/TV/index.js
+++ b/components/TV/index.js
@@ -1,0 +1,93 @@
+import React from "react";
+import Image from "next/image";
+import styled from "styled-components";
+import { useState, useEffect } from "react";
+import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
+import getGenreFrom from "../../utils/getGenreFrom";
+import { useFetch } from "../../hooks/useFetch";
+import { DataContext } from "../../pages/_app";
+import { useContext } from "react";
+
+const StyledDiv = styled.div`
+  height: 200px;
+  width: 120px;
+`;
+
+const StyledSection = styled.section`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  transition: 0.3s ease-out;
+
+  :hover {
+    transform: translateY(-10px);
+  }
+`;
+
+const StyledSectionText = styled.section`
+  width: 200px;
+  margin-left: 20px;
+  padding-left: 10px;
+`;
+
+const StyledParagraph = styled.p`
+  color: gray;
+`;
+
+const StyledImage = styled(Image)`
+  border-radius: 15px;
+`;
+
+const StyledHeader = styled.h4`
+  color: ${(props) => props.theme.fontColor};
+`;
+
+export default function TV({ movie }) {
+  const { theme } = useContext(DataContext);
+  /*  const [runtime, setRuntime] = useState(0);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch(
+          `/api/themoviedb/movie/${movie.id}?&language=eng-US`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setRuntime(data.runtime);
+        } else {
+          throw new Error("Something went wrong");
+        }
+      } catch (error) {
+        console.log(`Error: ${error.message}`);
+      }
+    }
+    fetchData();
+  }, [movie?.id]); */
+
+  return (
+    <>
+      <StyledSection>
+        <StyledDiv>
+          <StyledImage
+            src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
+            alt={movie?.name}
+            width={135}
+            height={200}
+          />
+        </StyledDiv>
+        <StyledSectionText>
+          <StyledHeader color={theme}>
+            {movie?.name} - <em>{movie?.first_air_date?.slice(0, 4)}</em>
+          </StyledHeader>
+          <StyledParagraph>{getGenreFrom(movie)}</StyledParagraph>
+          {runtime ? (
+            <StyledParagraph>{calculateRuntimeFrom(runtime)}</StyledParagraph>
+          ) : (
+            <p>Loading...</p>
+          )}
+        </StyledSectionText>
+      </StyledSection>
+    </>
+  );
+}

--- a/components/TV/index.js
+++ b/components/TV/index.js
@@ -4,15 +4,16 @@ import styled from "styled-components";
 import { useState, useEffect } from "react";
 import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
 import getGenreFrom from "../../utils/getGenreFrom";
-import { useFetch } from "../../hooks/useFetch";
 import { DataContext } from "../../pages/_app";
 import { useContext } from "react";
-import { OverviewWrapper } from "../Styled Components/QuickOverview";
-import { OverviewPosterContainer } from "../Styled Components/QuickOverview";
-import { OverviewPoster } from "../Styled Components/QuickOverview";
-import { OverviewTextContainer } from "../Styled Components/QuickOverview";
-import { OverviewHeader } from "../Styled Components/QuickOverview";
-import { OverviewText } from "../Styled Components/QuickOverview";
+import {
+  OverviewWrapper,
+  OverviewPosterContainer,
+  OverviewPoster,
+  OverviewTextContainer,
+  OverviewHeader,
+  OverviewText,
+} from "../Styled Components/QuickOverview";
 
 export default function TV({ movie }) {
   const { theme } = useContext(DataContext);

--- a/components/TV/index.js
+++ b/components/TV/index.js
@@ -44,17 +44,17 @@ const StyledHeader = styled.h4`
 
 export default function TV({ movie }) {
   const { theme } = useContext(DataContext);
-  /*  const [runtime, setRuntime] = useState(0);
+  const [runtime, setRuntime] = useState(0);
 
   useEffect(() => {
     async function fetchData() {
       try {
         const response = await fetch(
-          `/api/themoviedb/movie/${movie.id}?&language=eng-US`
+          `/api/themoviedb/tv/${movie.id}?&language=eng-US`
         );
         if (response.ok) {
           const data = await response.json();
-          setRuntime(data.runtime);
+          setRuntime(data.episode_run_time);
         } else {
           throw new Error("Something went wrong");
         }
@@ -63,7 +63,7 @@ export default function TV({ movie }) {
       }
     }
     fetchData();
-  }, [movie?.id]); */
+  }, [movie?.id]);
 
   return (
     <>

--- a/components/TV/index.js
+++ b/components/TV/index.js
@@ -7,40 +7,12 @@ import getGenreFrom from "../../utils/getGenreFrom";
 import { useFetch } from "../../hooks/useFetch";
 import { DataContext } from "../../pages/_app";
 import { useContext } from "react";
-
-const StyledDiv = styled.div`
-  height: 200px;
-  width: 120px;
-`;
-
-const StyledSection = styled.section`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 20px;
-  transition: 0.3s ease-out;
-
-  :hover {
-    transform: translateY(-10px);
-  }
-`;
-
-const StyledSectionText = styled.section`
-  width: 200px;
-  margin-left: 20px;
-  padding-left: 10px;
-`;
-
-const StyledParagraph = styled.p`
-  color: gray;
-`;
-
-const StyledImage = styled(Image)`
-  border-radius: 15px;
-`;
-
-const StyledHeader = styled.h4`
-  color: ${(props) => props.theme.fontColor};
-`;
+import { OverviewWrapper } from "../Styled Components/QuickOverview";
+import { OverviewPosterContainer } from "../Styled Components/QuickOverview";
+import { OverviewPoster } from "../Styled Components/QuickOverview";
+import { OverviewTextContainer } from "../Styled Components/QuickOverview";
+import { OverviewHeader } from "../Styled Components/QuickOverview";
+import { OverviewText } from "../Styled Components/QuickOverview";
 
 export default function TV({ movie }) {
   const { theme } = useContext(DataContext);
@@ -67,27 +39,27 @@ export default function TV({ movie }) {
 
   return (
     <>
-      <StyledSection>
-        <StyledDiv>
-          <StyledImage
+      <OverviewWrapper>
+        <OverviewPosterContainer>
+          <OverviewPoster
             src={`https://image.tmdb.org/t/p/original/${movie?.poster_path}`}
             alt={movie?.name}
             width={135}
             height={200}
           />
-        </StyledDiv>
-        <StyledSectionText>
-          <StyledHeader color={theme}>
+        </OverviewPosterContainer>
+        <OverviewTextContainer>
+          <OverviewHeader color={theme}>
             {movie?.name} - <em>{movie?.first_air_date?.slice(0, 4)}</em>
-          </StyledHeader>
-          <StyledParagraph>{getGenreFrom(movie)}</StyledParagraph>
+          </OverviewHeader>
+          <OverviewText>{getGenreFrom(movie)}</OverviewText>
           {runtime ? (
-            <StyledParagraph>{calculateRuntimeFrom(runtime)}</StyledParagraph>
+            <OverviewText>{calculateRuntimeFrom(runtime)}</OverviewText>
           ) : (
             <p>Loading...</p>
           )}
-        </StyledSectionText>
-      </StyledSection>
+        </OverviewTextContainer>
+      </OverviewWrapper>
     </>
   );
 }

--- a/components/TVDetail/index.js
+++ b/components/TVDetail/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Image from "next/image";
 import { DataContext } from "../../pages/_app";
 import getGenreFrom from "../../utils/getGenreFrom";
 import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
@@ -9,24 +8,24 @@ import PushButton from "../PushButton";
 import showWatchProviders from "../../utils/showWatchProviders";
 import Actors from "../Actors";
 import { useContext } from "react";
-import styled from "styled-components";
-import ReactPlayer from "react-player";
-import { DetailHeaderContainer } from "../Styled Components/DetailPage";
-import { DetailPageDescription } from "../Styled Components/DetailPage";
-import { DetailPageDescriptionText } from "../Styled Components/DetailPage";
-import { DetailPosterContainer } from "../Styled Components/DetailPage";
-import { DetailPoster } from "../Styled Components/DetailPage";
-import { DetailHeaderTitle } from "../Styled Components/DetailPage";
-import { DetailHeaderText } from "../Styled Components/DetailPage";
-import { DetailSynopsis } from "../Styled Components/DetailPage";
-import { TrailerButton } from "../Styled Components/DetailPage";
-import { TrailerContainer } from "../Styled Components/DetailPage";
-import { DetailSynopsisHeader } from "../Styled Components/DetailPage";
-import { DetailSynopsisText } from "../Styled Components/DetailPage";
-import { DetailAvailability } from "../Styled Components/DetailPage";
-import { DetailAvailabilityHeading } from "../Styled Components/DetailPage";
-import { DetailAvailabilityText } from "../Styled Components/DetailPage";
-import { Trailer } from "../Styled Components/DetailPage";
+import {
+  DetailHeaderContainer,
+  DetailPosterContainer,
+  DetailHeaderTitle,
+  DetailHeaderText,
+  DetailAvailability,
+  Trailer,
+  DetailAvailabilityText,
+  DetailAvailabilityHeading,
+  TrailerContainer,
+  DetailSynopsisText,
+  DetailSynopsisHeader,
+  TrailerButton,
+  DetailSynopsis,
+  DetailPoster,
+  DetailPageDescriptionText,
+  DetailPageDescription,
+} from "../Styled Components/DetailPage";
 
 export default function TVDetail({ movie }) {
   const [runtime, setRuntime] = useState(0);

--- a/components/TVDetail/index.js
+++ b/components/TVDetail/index.js
@@ -1,11 +1,6 @@
 import React from "react";
 import Image from "next/image";
-import {
-  WatchlistContext,
-  WatchedContext,
-  DataContext,
-  TrendingContext,
-} from "../../pages/_app";
+import { DataContext } from "../../pages/_app";
 import getGenreFrom from "../../utils/getGenreFrom";
 import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
 import { useState, useEffect } from "react";
@@ -14,105 +9,24 @@ import PushButton from "../PushButton";
 import showWatchProviders from "../../utils/showWatchProviders";
 import Actors from "../Actors";
 import { useContext } from "react";
-import { useRouter } from "next/router";
 import styled from "styled-components";
 import ReactPlayer from "react-player";
-import getIconForTheme from "../../utils/getIconForTheme";
-
-const StyledSectionHeader = styled.section`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const StyledHeaderMovieDetails = styled.h4`
-  margin: 15px;
-  margin-top: 0;
-`;
-
-const StyledSectionButtons = styled.section`
-  display: flex;
-`;
-
-const StyledButton = styled.button`
-  padding: 10px;
-  background-color: transparent;
-  border: none;
-`;
-
-const StyledShowTrailerButton = styled.button`
-  background-color: transparent;
-  color: ${(props) => props.theme.fontColor};
-  border: none;
-  margin-bottom: 15px;
-  cursor: pointer;
-`;
-
-const StyledPoster = styled(Image)`
-  border-radius: 30px;
-`;
-
-const StyledSectionPoster = styled.section`
-  display: flex;
-  justify-content: center;
-`;
-
-const StyledSectionQuickOverview = styled.section`
-  margin: 10px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const StyledMovieTitle = styled.h2`
-  margin: 5px;
-  text-align: center;
-`;
-
-const StyledMovieSubtitles = styled.p`
-  color: grey;
-  margin: 5px;
-`;
-
-const StyledSynopsisText = styled.p`
-  color: grey;
-`;
-
-const StyledSectionSynopsis = styled.section`
-  padding-left: 15px;
-  padding-right: 15px;
-  margin-top: 15px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-`;
-
-const StyledHeaderSynopsis = styled.h4`
-  align-self: flex-start;
-  margin: 0;
-`;
-
-const StyledTrailer = styled(ReactPlayer)`
-  margin-bottom: 15px;
-  align-self: flex-start;
-`;
-
-const StyledSectionTrailer = styled.section`
-  align-self: center;
-`;
-
-const StyledSectionAvailability = styled.section`
-  padding-left: 15px;
-`;
-
-const StyledAvailabilityHeading = styled.h4`
-  margin-bottom: 5px;
-`;
-
-const StyledAvailabilityText = styled.p`
-  margin-top: 5px;
-  color: gray;
-`;
+import { DetailHeaderContainer } from "../Styled Components/DetailPage";
+import { DetailPageDescription } from "../Styled Components/DetailPage";
+import { DetailPageDescriptionText } from "../Styled Components/DetailPage";
+import { DetailPosterContainer } from "../Styled Components/DetailPage";
+import { DetailPoster } from "../Styled Components/DetailPage";
+import { DetailHeaderTitle } from "../Styled Components/DetailPage";
+import { DetailHeaderText } from "../Styled Components/DetailPage";
+import { DetailSynopsis } from "../Styled Components/DetailPage";
+import { TrailerButton } from "../Styled Components/DetailPage";
+import { TrailerContainer } from "../Styled Components/DetailPage";
+import { DetailSynopsisHeader } from "../Styled Components/DetailPage";
+import { DetailSynopsisText } from "../Styled Components/DetailPage";
+import { DetailAvailability } from "../Styled Components/DetailPage";
+import { DetailAvailabilityHeading } from "../Styled Components/DetailPage";
+import { DetailAvailabilityText } from "../Styled Components/DetailPage";
+import { Trailer } from "../Styled Components/DetailPage";
 
 export default function TVDetail({ movie }) {
   const [runtime, setRuntime] = useState(0);
@@ -122,12 +36,8 @@ export default function TVDetail({ movie }) {
   const [youtubeKey, setYoutubeKey] = useState("");
   const [showTrailer, setShowTrailer] = useState(false);
   const { availabilityOption, theme } = useContext(DataContext);
-  const { handleToggleWatchList, watchlist } = useContext(WatchlistContext);
-  const { watched, handleToggleWatched } = useContext(WatchedContext);
-  const { trendingMovies } = useContext(TrendingContext);
 
   const shownActors = castActors.slice(0, 4);
-  const router = useRouter();
   const trailer = youtubeKey?.results?.find(
     (videoObject) => videoObject.type === "Trailer"
   );
@@ -217,38 +127,36 @@ export default function TVDetail({ movie }) {
   return (
     <>
       <PushButton />
-      <StyledSectionHeader>
-        <StyledHeaderMovieDetails>Movie Details</StyledHeaderMovieDetails>
-      </StyledSectionHeader>
-      <section>
-        <StyledSectionPoster>
-          <StyledPoster
-            src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
-            alt={movie.name}
-            width={202.5}
-            height={300}
-          />
-        </StyledSectionPoster>
-      </section>
-      <StyledSectionQuickOverview>
-        <StyledMovieTitle>{movie.name}</StyledMovieTitle>
-        <StyledMovieSubtitles>
+      <DetailPageDescription>
+        <DetailPageDescriptionText>Movie Details</DetailPageDescriptionText>
+      </DetailPageDescription>
+      <DetailPosterContainer>
+        <DetailPoster
+          src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+          alt={movie.name}
+          width={202.5}
+          height={300}
+        />
+      </DetailPosterContainer>
+      <DetailHeaderContainer>
+        <DetailHeaderTitle>{movie.name}</DetailHeaderTitle>
+        <DetailHeaderText>
           {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
-        </StyledMovieSubtitles>
-        <StyledMovieSubtitles>
+        </DetailHeaderText>
+        <DetailHeaderText>
           {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)}
-        </StyledMovieSubtitles>
-        <StyledMovieSubtitles>
+        </DetailHeaderText>
+        <DetailHeaderText>
           ca. {calculateRuntimeFrom(runtime)} per episode
-        </StyledMovieSubtitles>
-      </StyledSectionQuickOverview>
-      <StyledSectionSynopsis>
-        <StyledShowTrailerButton color={theme} onClick={displayTrailer}>
+        </DetailHeaderText>
+      </DetailHeaderContainer>
+      <DetailSynopsis>
+        <TrailerButton color={theme} onClick={displayTrailer}>
           {showTrailer ? "Hide the trailer" : "Watch the trailer"}
-        </StyledShowTrailerButton>
-        <StyledSectionTrailer>
+        </TrailerButton>
+        <TrailerContainer>
           {showTrailer ? (
-            <StyledTrailer
+            <Trailer
               controls={true}
               volume={0.2}
               width={300}
@@ -256,28 +164,27 @@ export default function TVDetail({ movie }) {
               url={`https://www.youtube.com/watch?v=${trailer.key}`}
             />
           ) : null}
-        </StyledSectionTrailer>
-        <StyledHeaderSynopsis>Synopsis:</StyledHeaderSynopsis>
-        <StyledSynopsisText>{movie.overview}</StyledSynopsisText>
-      </StyledSectionSynopsis>
-
+        </TrailerContainer>
+        <DetailSynopsisHeader>Synopsis:</DetailSynopsisHeader>
+        <DetailSynopsisText>{movie.overview}</DetailSynopsisText>
+      </DetailSynopsis>
       <Actors actors={shownActors} />
-      <StyledSectionAvailability>
+      <DetailAvailability>
         <h4>Availability:</h4>
         {availabilityOption === "all" && (
           <>
-            <StyledAvailabilityHeading>Flatrate</StyledAvailabilityHeading>
-            <StyledAvailabilityText>{`${showWatchProviders(
+            <DetailAvailabilityHeading>Flatrate</DetailAvailabilityHeading>
+            <DetailAvailabilityText>{`${showWatchProviders(
               streamingProviderFlatrate
-            )}`}</StyledAvailabilityText>
-            <StyledAvailabilityHeading>Renting</StyledAvailabilityHeading>
-            <StyledAvailabilityText>
+            )}`}</DetailAvailabilityText>
+            <DetailAvailabilityHeading>Renting</DetailAvailabilityHeading>
+            <DetailAvailabilityText>
               {`${showWatchProviders(streamingProviderRent)}`}
-            </StyledAvailabilityText>
-            <StyledAvailabilityHeading>Purchase </StyledAvailabilityHeading>
-            <StyledAvailabilityText>{`${showWatchProviders(
+            </DetailAvailabilityText>
+            <DetailAvailabilityHeading>Purchase </DetailAvailabilityHeading>
+            <DetailAvailabilityText>{`${showWatchProviders(
               streamingProviderBuy
-            )}`}</StyledAvailabilityText>
+            )}`}</DetailAvailabilityText>
           </>
         )}
         {availabilityOption === "flatrate" && (
@@ -290,7 +197,7 @@ export default function TVDetail({ movie }) {
         {availabilityOption === "purchase" && (
           <p>Purchase: {`${showWatchProviders(streamingProviderBuy)}`}</p>
         )}
-      </StyledSectionAvailability>
+      </DetailAvailability>
     </>
   );
 }

--- a/components/TVDetail/index.js
+++ b/components/TVDetail/index.js
@@ -236,8 +236,10 @@ export default function TVDetail({ movie }) {
           {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
         </StyledMovieSubtitles>
         <StyledMovieSubtitles>
-          {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)} • ca.{" "}
-          {calculateRuntimeFrom(runtime)} per episode
+          {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)}
+        </StyledMovieSubtitles>
+        <StyledMovieSubtitles>
+          ca. {calculateRuntimeFrom(runtime)} per episode
         </StyledMovieSubtitles>
       </StyledSectionQuickOverview>
       <StyledSectionSynopsis>

--- a/components/TVDetail/index.js
+++ b/components/TVDetail/index.js
@@ -236,8 +236,8 @@ export default function TVDetail({ movie }) {
           {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
         </StyledMovieSubtitles>
         <StyledMovieSubtitles>
-          {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)} •{" "}
-          {calculateRuntimeFrom(runtime)}
+          {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)} • ca.{" "}
+          {calculateRuntimeFrom(runtime)} per episode
         </StyledMovieSubtitles>
       </StyledSectionQuickOverview>
       <StyledSectionSynopsis>

--- a/components/TVDetail/index.js
+++ b/components/TVDetail/index.js
@@ -1,0 +1,294 @@
+import React from "react";
+import Image from "next/image";
+import {
+  WatchlistContext,
+  WatchedContext,
+  DataContext,
+  TrendingContext,
+} from "../../pages/_app";
+import getGenreFrom from "../../utils/getGenreFrom";
+import calculateRuntimeFrom from "../../utils/calculateRuntimeFrom";
+import { useState, useEffect } from "react";
+import getPopularityDecimal from "../../utils/getPopularityDecimal";
+import PushButton from "../PushButton";
+import showWatchProviders from "../../utils/showWatchProviders";
+import Actors from "../Actors";
+import { useContext } from "react";
+import { useRouter } from "next/router";
+import styled from "styled-components";
+import ReactPlayer from "react-player";
+import getIconForTheme from "../../utils/getIconForTheme";
+
+const StyledSectionHeader = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledHeaderMovieDetails = styled.h4`
+  margin: 15px;
+  margin-top: 0;
+`;
+
+const StyledSectionButtons = styled.section`
+  display: flex;
+`;
+
+const StyledButton = styled.button`
+  padding: 10px;
+  background-color: transparent;
+  border: none;
+`;
+
+const StyledShowTrailerButton = styled.button`
+  background-color: transparent;
+  color: ${(props) => props.theme.fontColor};
+  border: none;
+  margin-bottom: 15px;
+  cursor: pointer;
+`;
+
+const StyledPoster = styled(Image)`
+  border-radius: 30px;
+`;
+
+const StyledSectionPoster = styled.section`
+  display: flex;
+  justify-content: center;
+`;
+
+const StyledSectionQuickOverview = styled.section`
+  margin: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledMovieTitle = styled.h2`
+  margin: 5px;
+  text-align: center;
+`;
+
+const StyledMovieSubtitles = styled.p`
+  color: grey;
+  margin: 5px;
+`;
+
+const StyledSynopsisText = styled.p`
+  color: grey;
+`;
+
+const StyledSectionSynopsis = styled.section`
+  padding-left: 15px;
+  padding-right: 15px;
+  margin-top: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`;
+
+const StyledHeaderSynopsis = styled.h4`
+  align-self: flex-start;
+  margin: 0;
+`;
+
+const StyledTrailer = styled(ReactPlayer)`
+  margin-bottom: 15px;
+  align-self: flex-start;
+`;
+
+const StyledSectionTrailer = styled.section`
+  align-self: center;
+`;
+
+const StyledSectionAvailability = styled.section`
+  padding-left: 15px;
+`;
+
+const StyledAvailabilityHeading = styled.h4`
+  margin-bottom: 5px;
+`;
+
+const StyledAvailabilityText = styled.p`
+  margin-top: 5px;
+  color: gray;
+`;
+
+export default function TVDetail({ movie }) {
+  const [runtime, setRuntime] = useState(0);
+  const [movieDetails, setMovieDetails] = useState(null);
+  const [watchProvider, setWatchProvider] = useState("");
+  const [castActors, setCastActors] = useState("");
+  const [youtubeKey, setYoutubeKey] = useState("");
+  const [showTrailer, setShowTrailer] = useState(false);
+  const { availabilityOption, theme } = useContext(DataContext);
+  const { handleToggleWatchList, watchlist } = useContext(WatchlistContext);
+  const { watched, handleToggleWatched } = useContext(WatchedContext);
+  const { trendingMovies } = useContext(TrendingContext);
+
+  const shownActors = castActors.slice(0, 4);
+  const router = useRouter();
+  const trailer = youtubeKey?.results?.find(
+    (videoObject) => videoObject.type === "Trailer"
+  );
+  const streamingProviderFlatrate = watchProvider?.flatrate;
+  const streamingProviderBuy = watchProvider?.buy;
+  const streamingProviderRent = watchProvider?.rent;
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch(
+          `/api/themoviedb/tv/${movie.id}?&language=eng-US`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setRuntime(data.episode_run_time);
+          setMovieDetails(data);
+        } else {
+          throw new Error("Something went wrong");
+        }
+      } catch (error) {
+        console.log(`Error: ${error.message}`);
+      }
+    }
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch(
+          `/api/themoviedb/tv/${movie.id}/watch/providers?`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setWatchProvider(data.results.DE);
+        } else {
+          throw new Error("Something went wrong");
+        }
+      } catch (error) {
+        console.log(`Error: ${error.message}`);
+      }
+    }
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch(`/api/themoviedb/tv/${movie.id}/credits?`);
+        if (response.ok) {
+          const data = await response.json();
+          setCastActors(data.cast);
+        } else {
+          throw new Error("Something went wrong");
+        }
+      } catch (error) {
+        console.log(`Error: ${error.message}`);
+      }
+    }
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch(
+          `/api/themoviedb/tv/${movie.id}/videos?&language=en-US`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setYoutubeKey(data);
+        } else {
+          throw new Error("Something went wrong");
+        }
+      } catch (error) {
+        console.log(`Error: ${error.message}`);
+      }
+    }
+    fetchData();
+  }, []);
+
+  function displayTrailer() {
+    setShowTrailer(!showTrailer);
+  }
+
+  return (
+    <>
+      <PushButton />
+      <StyledSectionHeader>
+        <StyledHeaderMovieDetails>Movie Details</StyledHeaderMovieDetails>
+      </StyledSectionHeader>
+      <section>
+        <StyledSectionPoster>
+          <StyledPoster
+            src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+            alt={movie.name}
+            width={202.5}
+            height={300}
+          />
+        </StyledSectionPoster>
+      </section>
+      <StyledSectionQuickOverview>
+        <StyledMovieTitle>{movie.name}</StyledMovieTitle>
+        <StyledMovieSubtitles>
+          {getPopularityDecimal(movieDetails?.vote_average)}/10 Rating
+        </StyledMovieSubtitles>
+        <StyledMovieSubtitles>
+          {getGenreFrom(movie)} • {movie.first_air_date?.slice(0, 4)} •{" "}
+          {calculateRuntimeFrom(runtime)}
+        </StyledMovieSubtitles>
+      </StyledSectionQuickOverview>
+      <StyledSectionSynopsis>
+        <StyledShowTrailerButton color={theme} onClick={displayTrailer}>
+          {showTrailer ? "Hide the trailer" : "Watch the trailer"}
+        </StyledShowTrailerButton>
+        <StyledSectionTrailer>
+          {showTrailer ? (
+            <StyledTrailer
+              controls={true}
+              volume={0.2}
+              width={300}
+              height={200}
+              url={`https://www.youtube.com/watch?v=${trailer.key}`}
+            />
+          ) : null}
+        </StyledSectionTrailer>
+        <StyledHeaderSynopsis>Synopsis:</StyledHeaderSynopsis>
+        <StyledSynopsisText>{movie.overview}</StyledSynopsisText>
+      </StyledSectionSynopsis>
+
+      <Actors actors={shownActors} />
+      <StyledSectionAvailability>
+        <h4>Availability:</h4>
+        {availabilityOption === "all" && (
+          <>
+            <StyledAvailabilityHeading>Flatrate</StyledAvailabilityHeading>
+            <StyledAvailabilityText>{`${showWatchProviders(
+              streamingProviderFlatrate
+            )}`}</StyledAvailabilityText>
+            <StyledAvailabilityHeading>Renting</StyledAvailabilityHeading>
+            <StyledAvailabilityText>
+              {`${showWatchProviders(streamingProviderRent)}`}
+            </StyledAvailabilityText>
+            <StyledAvailabilityHeading>Purchase </StyledAvailabilityHeading>
+            <StyledAvailabilityText>{`${showWatchProviders(
+              streamingProviderBuy
+            )}`}</StyledAvailabilityText>
+          </>
+        )}
+        {availabilityOption === "flatrate" && (
+          <p>Flatrate {`${showWatchProviders(streamingProviderFlatrate)}`}</p>
+        )}
+        {availabilityOption === "rent" && (
+          <p>Renting {`${showWatchProviders(streamingProviderRent)}`}</p>
+        )}
+
+        {availabilityOption === "purchase" && (
+          <p>Purchase: {`${showWatchProviders(streamingProviderBuy)}`}</p>
+        )}
+      </StyledSectionAvailability>
+    </>
+  );
+}

--- a/components/TVDetailFooter/index.js
+++ b/components/TVDetailFooter/index.js
@@ -1,64 +1,20 @@
 import React from "react";
-import styled from "styled-components";
-import Link from "next/link";
-import Image from "next/image";
 import { useRouter } from "next/router";
-import getIconForTheme from "../../utils/getIconForTheme";
 import {
   DataContext,
   TrendingContext,
   WatchlistTVContext,
-  WatchedContext,
   WatchedTVContext,
 } from "../../pages/_app";
 import { useContext } from "react";
-
-const StyledFooter = styled.footer`
-  background-color: ${(props) => props.theme.body};
-  position: fixed;
-  width: 100%;
-  height: 80px;
-  bottom: -1px;
-  border-top: 1px solid grey;
-`;
-
-const StyledNavBar = styled.nav``;
-
-const StyledList = styled.ul`
-  list-style-type: none;
-  display: flex;
-  justify-content: space-around;
-  padding-inline-start: 0;
-`;
-
-const StyledListItem = styled.li`
-  font-size: 10px;
-`;
-
-const StyledDiv = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const StyledButton = styled.button`
-  position: relative;
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-  align-items: center;
-  height: 45px;
-  width: 160px;
-  border-radius: 20px;
-  border: none;
-  background-color: ${(props) => props.color};
-`;
-
-const StyledIcon = styled(Image)``;
-
-const StyledIconText = styled.p`
-  color: white;
-`;
+import { DetailFooter } from "../Styled Components/DetailPageFooter";
+import { DetailNavBar } from "../Styled Components/DetailPageFooter";
+import { NavBarList } from "../Styled Components/DetailPageFooter";
+import { NavBarListItem } from "../Styled Components/DetailPageFooter";
+import { DetailNavBarButtonContainer } from "../Styled Components/DetailPageFooter";
+import { NavBarListButton } from "../Styled Components/DetailPageFooter";
+import { NavBarButtonIcon } from "../Styled Components/DetailPageFooter";
+import { NavBarButtonText } from "../Styled Components/DetailPageFooter";
 
 export default function TVDetailFooter({ movie }) {
   const { theme } = useContext(DataContext);
@@ -66,7 +22,6 @@ export default function TVDetailFooter({ movie }) {
   const { handleToggleWatchListTV, watchlistTV } =
     useContext(WatchlistTVContext);
   const { handleToggleWatchedTV, watchedTV } = useContext(WatchedTVContext);
-  const { handleToggleWatched, watched } = useContext(WatchedContext);
 
   const router = useRouter();
 
@@ -96,12 +51,12 @@ export default function TVDetailFooter({ movie }) {
   }
 
   return (
-    <StyledFooter color={theme}>
-      <StyledNavBar>
-        <StyledList>
-          <StyledListItem>
-            <StyledDiv>
-              <StyledButton
+    <DetailFooter color={theme}>
+      <DetailNavBar>
+        <NavBarList>
+          <NavBarListItem>
+            <DetailNavBarButtonContainer>
+              <NavBarListButton
                 color={
                   JSON.stringify(watchlistTV).includes(JSON.stringify(movie))
                     ? "#f97b7b"
@@ -113,31 +68,31 @@ export default function TVDetailFooter({ movie }) {
               >
                 {JSON.stringify(watchlistTV).includes(JSON.stringify(movie)) ? (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"in-watchlist"}
                       src={`/in-watchlist.png`}
                       width={20}
                       height={20}
                     />{" "}
-                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                    <NavBarButtonText color={theme}>Watchlist</NavBarButtonText>
                   </>
                 ) : (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"not-in-watchlist"}
                       src={`/not-in-watchlist.png`}
                       width={20}
                       height={20}
                     />
-                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                    <NavBarButtonText color={theme}>Watchlist</NavBarButtonText>
                   </>
                 )}
-              </StyledButton>
-            </StyledDiv>
-          </StyledListItem>
-          <StyledListItem>
-            <StyledDiv>
-              <StyledButton
+              </NavBarListButton>
+            </DetailNavBarButtonContainer>
+          </NavBarListItem>
+          <NavBarListItem>
+            <DetailNavBarButtonContainer>
+              <NavBarListButton
                 color={
                   JSON.stringify(watchedTV).includes(JSON.stringify(movie))
                     ? "#f97b7b"
@@ -149,31 +104,31 @@ export default function TVDetailFooter({ movie }) {
               >
                 {JSON.stringify(watchedTV).includes(JSON.stringify(movie)) ? (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"in-watched"}
                       src={`/in-watched.png`}
                       width={20}
                       height={20}
                     />
 
-                    <StyledIconText color={theme}>Watched</StyledIconText>
+                    <NavBarButtonText color={theme}>Watched</NavBarButtonText>
                   </>
                 ) : (
                   <>
-                    <StyledIcon
+                    <NavBarButtonIcon
                       alt={"not-in-watched"}
                       src={`/not-in-watched.png`}
                       width={20}
                       height={20}
                     />
-                    <StyledIconText color={theme}>Watched</StyledIconText>
+                    <NavBarButtonText color={theme}>Watched</NavBarButtonText>
                   </>
                 )}
-              </StyledButton>
-            </StyledDiv>
-          </StyledListItem>
-        </StyledList>
-      </StyledNavBar>
-    </StyledFooter>
+              </NavBarListButton>
+            </DetailNavBarButtonContainer>
+          </NavBarListItem>
+        </NavBarList>
+      </DetailNavBar>
+    </DetailFooter>
   );
 }

--- a/components/TVDetailFooter/index.js
+++ b/components/TVDetailFooter/index.js
@@ -1,0 +1,177 @@
+import React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+import Image from "next/image";
+import { useRouter } from "next/router";
+import getIconForTheme from "../../utils/getIconForTheme";
+import {
+  DataContext,
+  TrendingContext,
+  WatchlistTVContext,
+  WatchedContext,
+} from "../../pages/_app";
+import { useContext } from "react";
+
+const StyledFooter = styled.footer`
+  background-color: ${(props) => props.theme.body};
+  position: fixed;
+  width: 100%;
+  height: 80px;
+  bottom: -1px;
+  border-top: 1px solid grey;
+`;
+
+const StyledNavBar = styled.nav``;
+
+const StyledList = styled.ul`
+  list-style-type: none;
+  display: flex;
+  justify-content: space-around;
+  padding-inline-start: 0;
+`;
+
+const StyledListItem = styled.li`
+  font-size: 10px;
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledButton = styled.button`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  align-items: center;
+  height: 45px;
+  width: 160px;
+  border-radius: 20px;
+  border: none;
+  background-color: ${(props) => props.color};
+`;
+
+const StyledIcon = styled(Image)``;
+
+const StyledIconText = styled.p`
+  color: white;
+`;
+
+export default function TVDetailFooter({ movie }) {
+  const { theme } = useContext(DataContext);
+  const { trendingMovies } = useContext(TrendingContext);
+  const { handleToggleWatchListTV, watchlistTV } =
+    useContext(WatchlistTVContext);
+  const { handleToggleWatched, watched } = useContext(WatchedContext);
+
+  const router = useRouter();
+
+  function handleRemoveInWatchlistTVPage(movie) {
+    if (router.asPath.includes("my-watchlist")) {
+      handleToggleWatchListTV(movie);
+      router.push("/my-watchlist");
+    } else if (
+      trendingMovies.find((trendingMovie) => trendingMovie.id === movie.id)
+    ) {
+      handleToggleWatchListTV(movie);
+    } else if (movie.id.toString().length === router.asPath.length - 1) {
+      handleToggleWatchListTV(movie);
+      router.push("/");
+    } else {
+      handleToggleWatchListTV(movie);
+    }
+  }
+
+  function handleRemoveInWatchedPage(movie) {
+    if (router.asPath.includes("my-watched")) {
+      handleToggleWatched(movie);
+      router.push("/my-watched");
+    } else {
+      handleToggleWatched(movie);
+    }
+  }
+
+  return (
+    <StyledFooter color={theme}>
+      <StyledNavBar>
+        <StyledList>
+          <StyledListItem>
+            <StyledDiv>
+              <StyledButton
+                color={
+                  JSON.stringify(watchlistTV).includes(JSON.stringify(movie))
+                    ? "#f97b7b"
+                    : "#faa5a5"
+                }
+                onClick={() => {
+                  handleRemoveInWatchlistTVPage(movie);
+                }}
+              >
+                {JSON.stringify(watchlistTV).includes(JSON.stringify(movie)) ? (
+                  <>
+                    <StyledIcon
+                      alt={"in-watchlist"}
+                      src={`/in-watchlist.png`}
+                      width={20}
+                      height={20}
+                    />{" "}
+                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                  </>
+                ) : (
+                  <>
+                    <StyledIcon
+                      alt={"not-in-watchlist"}
+                      src={`/not-in-watchlist.png`}
+                      width={20}
+                      height={20}
+                    />
+                    <StyledIconText color={theme}>Watchlist</StyledIconText>
+                  </>
+                )}
+              </StyledButton>
+            </StyledDiv>
+          </StyledListItem>
+          <StyledListItem>
+            <StyledDiv>
+              <StyledButton
+                color={
+                  JSON.stringify(watched).includes(JSON.stringify(movie))
+                    ? "#f97b7b"
+                    : "#faa5a5"
+                }
+                onClick={() => {
+                  handleRemoveInWatchedPage(movie);
+                }}
+              >
+                {JSON.stringify(watched).includes(JSON.stringify(movie)) ? (
+                  <>
+                    <StyledIcon
+                      alt={"in-watched"}
+                      src={`/in-watched.png`}
+                      width={20}
+                      height={20}
+                    />
+
+                    <StyledIconText color={theme}>Watched</StyledIconText>
+                  </>
+                ) : (
+                  <>
+                    <StyledIcon
+                      alt={"not-in-watched"}
+                      src={`/not-in-watched.png`}
+                      width={20}
+                      height={20}
+                    />
+                    <StyledIconText color={theme}>Watched</StyledIconText>
+                  </>
+                )}
+              </StyledButton>
+            </StyledDiv>
+          </StyledListItem>
+        </StyledList>
+      </StyledNavBar>
+    </StyledFooter>
+  );
+}

--- a/components/TVDetailFooter/index.js
+++ b/components/TVDetailFooter/index.js
@@ -7,14 +7,16 @@ import {
   WatchedTVContext,
 } from "../../pages/_app";
 import { useContext } from "react";
-import { DetailFooter } from "../Styled Components/DetailPageFooter";
-import { DetailNavBar } from "../Styled Components/DetailPageFooter";
-import { NavBarList } from "../Styled Components/DetailPageFooter";
-import { NavBarListItem } from "../Styled Components/DetailPageFooter";
-import { DetailNavBarButtonContainer } from "../Styled Components/DetailPageFooter";
-import { NavBarListButton } from "../Styled Components/DetailPageFooter";
-import { NavBarButtonIcon } from "../Styled Components/DetailPageFooter";
-import { NavBarButtonText } from "../Styled Components/DetailPageFooter";
+import {
+  DetailFooter,
+  DetailNavBar,
+  NavBarList,
+  NavBarListButton,
+  NavBarButtonIcon,
+  NavBarButtonText,
+  DetailNavBarButtonContainer,
+  NavBarListItem,
+} from "../Styled Components/DetailPageFooter";
 
 export default function TVDetailFooter({ movie }) {
   const { theme } = useContext(DataContext);

--- a/components/TVDetailFooter/index.js
+++ b/components/TVDetailFooter/index.js
@@ -9,6 +9,7 @@ import {
   TrendingContext,
   WatchlistTVContext,
   WatchedContext,
+  WatchedTVContext,
 } from "../../pages/_app";
 import { useContext } from "react";
 
@@ -64,6 +65,7 @@ export default function TVDetailFooter({ movie }) {
   const { trendingMovies } = useContext(TrendingContext);
   const { handleToggleWatchListTV, watchlistTV } =
     useContext(WatchlistTVContext);
+  const { handleToggleWatchedTV, watchedTV } = useContext(WatchedTVContext);
   const { handleToggleWatched, watched } = useContext(WatchedContext);
 
   const router = useRouter();
@@ -84,12 +86,12 @@ export default function TVDetailFooter({ movie }) {
     }
   }
 
-  function handleRemoveInWatchedPage(movie) {
+  function handleRemoveInWatchedTVPage(movie) {
     if (router.asPath.includes("my-watched")) {
-      handleToggleWatched(movie);
+      handleToggleWatchedTV(movie);
       router.push("/my-watched");
     } else {
-      handleToggleWatched(movie);
+      handleToggleWatchedTV(movie);
     }
   }
 
@@ -137,15 +139,15 @@ export default function TVDetailFooter({ movie }) {
             <StyledDiv>
               <StyledButton
                 color={
-                  JSON.stringify(watched).includes(JSON.stringify(movie))
+                  JSON.stringify(watchedTV).includes(JSON.stringify(movie))
                     ? "#f97b7b"
                     : "#faa5a5"
                 }
                 onClick={() => {
-                  handleRemoveInWatchedPage(movie);
+                  handleRemoveInWatchedTVPage(movie);
                 }}
               >
-                {JSON.stringify(watched).includes(JSON.stringify(movie)) ? (
+                {JSON.stringify(watchedTV).includes(JSON.stringify(movie)) ? (
                   <>
                     <StyledIcon
                       alt={"in-watched"}

--- a/components/TVGrid/index.js
+++ b/components/TVGrid/index.js
@@ -1,0 +1,23 @@
+import React from "react";
+import Image from "next/image";
+import styled from "styled-components";
+
+const StyledImage = styled(Image)`
+  border-radius: 10px;
+  &:hover {
+    transform: scale(1.05);
+    border: 1px solid #f97b7b;
+    cursor: pointer;
+  }
+`;
+
+export default function TVGrid({ movie }) {
+  return (
+    <StyledImage
+      src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+      alt={movie.name}
+      width={100}
+      height={145}
+    />
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -73,7 +73,6 @@ export default function App({ Component, pageProps }) {
     event.preventDefault();
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
-    console.log(data);
     setSearch(data.search);
   }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,9 +13,13 @@ export const CinemaContext = createContext();
 export const TrendingContext = createContext();
 export const WatchedContext = createContext();
 export const MediaContext = createContext();
+export const WatchlistTVContext = createContext();
 
 export default function App({ Component, pageProps }) {
   const [watchlist, setWatchlist] = useLocalStorageState("newWatchlist", {
+    defaultValue: [],
+  });
+  const [watchlistTV, setWatchlistTV] = useLocalStorageState("newWatchlistTV", {
     defaultValue: [],
   });
   const [watched, setWatched] = useLocalStorageState("newWatched", {
@@ -90,6 +94,20 @@ export default function App({ Component, pageProps }) {
     }
   }
 
+  function handleToggleWatchListTV(newMovie) {
+    if (
+      !watchlistTV.some(
+        (movie) => JSON.stringify(movie) === JSON.stringify(newMovie)
+      )
+    ) {
+      setWatchlistTV([...watchlistTV, newMovie]);
+    } else {
+      setWatchlistTV(
+        watchlistTV.filter((watchMovie) => watchMovie.id !== newMovie.id)
+      );
+    }
+  }
+
   function handleToggleWatched(newMovie) {
     if (
       !watched.some(
@@ -133,6 +151,8 @@ export default function App({ Component, pageProps }) {
     setMediaTypeMovies(value);
   }
 
+  console.log(watchlistTV);
+
   return (
     <>
       <Head>
@@ -140,44 +160,48 @@ export default function App({ Component, pageProps }) {
       </Head>
       <ThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
         <GlobalStyles />
-        <MediaContext.Provider
-          value={{ handleMediaTypeChange, mediaTypeMovies }}
+        <WatchlistTVContext.Provider
+          value={{ handleToggleWatchListTV, watchlistTV }}
         >
-          <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
-            <TrendingContext.Provider
-              value={{ dayTrending, trendingMovies, handleTrendingSort }}
-            >
-              <CinemaContext.Provider
-                value={{ currentlyInCinemas, upcomingMovies }}
+          <MediaContext.Provider
+            value={{ handleMediaTypeChange, mediaTypeMovies }}
+          >
+            <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
+              <TrendingContext.Provider
+                value={{ dayTrending, trendingMovies, handleTrendingSort }}
               >
-                <WatchlistContext.Provider
-                  value={{ handleToggleWatchList, watchlist }}
+                <CinemaContext.Provider
+                  value={{ currentlyInCinemas, upcomingMovies }}
                 >
-                  <DataContext.Provider
-                    value={{
-                      search,
-                      resultsPage,
-                      resetResultsPage,
-                      totalSearchResults,
-                      totalSearchPages,
-                      handleNextPage,
-                      handlePrevPage,
-                      getAvailabilitySeletion,
-                      availabilityOption,
-                      themeToggler,
-                      theme,
-                      DataContext,
-                      handleFormSubmit,
-                      movies,
-                    }}
+                  <WatchlistContext.Provider
+                    value={{ handleToggleWatchList, watchlist }}
                   >
-                    <Component {...pageProps} />
-                  </DataContext.Provider>
-                </WatchlistContext.Provider>
-              </CinemaContext.Provider>
-            </TrendingContext.Provider>
-          </WatchedContext.Provider>
-        </MediaContext.Provider>
+                    <DataContext.Provider
+                      value={{
+                        search,
+                        resultsPage,
+                        resetResultsPage,
+                        totalSearchResults,
+                        totalSearchPages,
+                        handleNextPage,
+                        handlePrevPage,
+                        getAvailabilitySeletion,
+                        availabilityOption,
+                        themeToggler,
+                        theme,
+                        DataContext,
+                        handleFormSubmit,
+                        movies,
+                      }}
+                    >
+                      <Component {...pageProps} />
+                    </DataContext.Provider>
+                  </WatchlistContext.Provider>
+                </CinemaContext.Provider>
+              </TrendingContext.Provider>
+            </WatchedContext.Provider>
+          </MediaContext.Provider>
+        </WatchlistTVContext.Provider>
       </ThemeProvider>
     </>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,17 +31,17 @@ export default function App({ Component, pageProps }) {
     defaultValue: "light",
   });
   const [resultsPage, setResultsPage] = useState(1);
-  const [mediaTypeMovies, setMediaTypeMovies] = useState(true);
+  const [mediaTypeMovies, setMediaTypeMovies] = useState("movie");
 
   function resetResultsPage() {
     setResultsPage(1);
   }
 
   const moviesData = useLocalStorageFetch(
-    `/api/themoviedb/search/movie?&language=eng-US&query=${search}&page=${resultsPage}`,
+    `/api/themoviedb/search/${mediaTypeMovies}?&language=eng-US&query=${search}&page=${resultsPage}`,
     "newMovies",
     [],
-    `/api/themoviedb/search/movie?&language=eng-US&query=${search}&page=${resultsPage}`
+    `/api/themoviedb/search/${mediaTypeMovies}?&language=eng-US&query=${search}&page=${resultsPage}`
   );
 
   const totalSearchPages = moviesData.total_pages;
@@ -130,8 +130,8 @@ export default function App({ Component, pageProps }) {
     }
   }
 
-  function handleMediaTypeChange(boolean) {
-    setMediaTypeMovies(boolean);
+  function handleMediaTypeChange(value) {
+    setMediaTypeMovies(value);
   }
 
   return (

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -169,9 +169,6 @@ export default function App({ Component, pageProps }) {
     setMediaTypeMovies(value);
   }
 
-  console.log("new watchlist", watchlistTV);
-  console.log("new watched", watchedTV);
-
   return (
     <>
       <Head>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,6 +12,7 @@ export const WatchlistContext = createContext();
 export const CinemaContext = createContext();
 export const TrendingContext = createContext();
 export const WatchedContext = createContext();
+export const MediaContext = createContext();
 
 export default function App({ Component, pageProps }) {
   const [watchlist, setWatchlist] = useLocalStorageState("newWatchlist", {
@@ -30,6 +31,7 @@ export default function App({ Component, pageProps }) {
     defaultValue: "light",
   });
   const [resultsPage, setResultsPage] = useState(1);
+  const [mediaTypeMovies, setMediaTypeMovies] = useState(true);
 
   function resetResultsPage() {
     setResultsPage(1);
@@ -71,6 +73,7 @@ export default function App({ Component, pageProps }) {
     event.preventDefault();
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
+    console.log(data);
     setSearch(data.search);
   }
 
@@ -127,6 +130,10 @@ export default function App({ Component, pageProps }) {
     }
   }
 
+  function handleMediaTypeChange(boolean) {
+    setMediaTypeMovies(boolean);
+  }
+
   return (
     <>
       <Head>
@@ -134,40 +141,44 @@ export default function App({ Component, pageProps }) {
       </Head>
       <ThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
         <GlobalStyles />
-        <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
-          <TrendingContext.Provider
-            value={{ dayTrending, trendingMovies, handleTrendingSort }}
-          >
-            <CinemaContext.Provider
-              value={{ currentlyInCinemas, upcomingMovies }}
+        <MediaContext.Provider
+          value={{ handleMediaTypeChange, mediaTypeMovies }}
+        >
+          <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
+            <TrendingContext.Provider
+              value={{ dayTrending, trendingMovies, handleTrendingSort }}
             >
-              <WatchlistContext.Provider
-                value={{ handleToggleWatchList, watchlist }}
+              <CinemaContext.Provider
+                value={{ currentlyInCinemas, upcomingMovies }}
               >
-                <DataContext.Provider
-                  value={{
-                    search,
-                    resultsPage,
-                    resetResultsPage,
-                    totalSearchResults,
-                    totalSearchPages,
-                    handleNextPage,
-                    handlePrevPage,
-                    getAvailabilitySeletion,
-                    availabilityOption,
-                    themeToggler,
-                    theme,
-                    DataContext,
-                    handleFormSubmit,
-                    movies,
-                  }}
+                <WatchlistContext.Provider
+                  value={{ handleToggleWatchList, watchlist }}
                 >
-                  <Component {...pageProps} />
-                </DataContext.Provider>
-              </WatchlistContext.Provider>
-            </CinemaContext.Provider>
-          </TrendingContext.Provider>
-        </WatchedContext.Provider>
+                  <DataContext.Provider
+                    value={{
+                      search,
+                      resultsPage,
+                      resetResultsPage,
+                      totalSearchResults,
+                      totalSearchPages,
+                      handleNextPage,
+                      handlePrevPage,
+                      getAvailabilitySeletion,
+                      availabilityOption,
+                      themeToggler,
+                      theme,
+                      DataContext,
+                      handleFormSubmit,
+                      movies,
+                    }}
+                  >
+                    <Component {...pageProps} />
+                  </DataContext.Provider>
+                </WatchlistContext.Provider>
+              </CinemaContext.Provider>
+            </TrendingContext.Provider>
+          </WatchedContext.Provider>
+        </MediaContext.Provider>
       </ThemeProvider>
     </>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -33,6 +33,7 @@ export default function App({ Component, pageProps }) {
     "newAvailability",
     { defaultValue: "all" }
   );
+
   const [dayTrending, setDayTrending] = useState(true);
   const [search, setSearch] = useState("");
   const [theme, setTheme] = useLocalStorageState("newTheme", {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,12 +8,13 @@ import { ThemeProvider } from "styled-components";
 import { lightTheme, darkTheme, GlobalStyles } from "../styles";
 
 export const DataContext = createContext();
+export const MediaContext = createContext();
 export const WatchlistContext = createContext();
+export const WatchedContext = createContext();
+export const WatchlistTVContext = createContext();
+export const WatchedTVContext = createContext();
 export const CinemaContext = createContext();
 export const TrendingContext = createContext();
-export const WatchedContext = createContext();
-export const MediaContext = createContext();
-export const WatchlistTVContext = createContext();
 
 export default function App({ Component, pageProps }) {
   const [watchlist, setWatchlist] = useLocalStorageState("newWatchlist", {
@@ -23,6 +24,9 @@ export default function App({ Component, pageProps }) {
     defaultValue: [],
   });
   const [watched, setWatched] = useLocalStorageState("newWatched", {
+    defaultValue: [],
+  });
+  const [watchedTV, setWatchedTV] = useLocalStorageState("newWatchedTV", {
     defaultValue: [],
   });
   const [availabilityOption, setAvailabilityOption] = useLocalStorageState(
@@ -122,6 +126,20 @@ export default function App({ Component, pageProps }) {
     }
   }
 
+  function handleToggleWatchedTV(newMovie) {
+    if (
+      !watchedTV.some(
+        (movie) => JSON.stringify(movie) === JSON.stringify(newMovie)
+      )
+    ) {
+      setWatchedTV([...watchedTV, newMovie]);
+    } else {
+      setWatchedTV(
+        watchedTV.filter((watchedMovie) => watchedMovie.id !== newMovie.id)
+      );
+    }
+  }
+
   function handleTrendingSort(boolean) {
     setDayTrending(boolean);
   }
@@ -151,7 +169,8 @@ export default function App({ Component, pageProps }) {
     setMediaTypeMovies(value);
   }
 
-  console.log(watchlistTV);
+  console.log("new watchlist", watchlistTV);
+  console.log("new watched", watchedTV);
 
   return (
     <>
@@ -160,48 +179,50 @@ export default function App({ Component, pageProps }) {
       </Head>
       <ThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
         <GlobalStyles />
-        <WatchlistTVContext.Provider
-          value={{ handleToggleWatchListTV, watchlistTV }}
-        >
-          <MediaContext.Provider
-            value={{ handleMediaTypeChange, mediaTypeMovies }}
+        <WatchedTVContext.Provider value={{ handleToggleWatchedTV, watchedTV }}>
+          <WatchlistTVContext.Provider
+            value={{ handleToggleWatchListTV, watchlistTV }}
           >
-            <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
-              <TrendingContext.Provider
-                value={{ dayTrending, trendingMovies, handleTrendingSort }}
-              >
-                <CinemaContext.Provider
-                  value={{ currentlyInCinemas, upcomingMovies }}
+            <MediaContext.Provider
+              value={{ handleMediaTypeChange, mediaTypeMovies }}
+            >
+              <WatchedContext.Provider value={{ watched, handleToggleWatched }}>
+                <TrendingContext.Provider
+                  value={{ dayTrending, trendingMovies, handleTrendingSort }}
                 >
-                  <WatchlistContext.Provider
-                    value={{ handleToggleWatchList, watchlist }}
+                  <CinemaContext.Provider
+                    value={{ currentlyInCinemas, upcomingMovies }}
                   >
-                    <DataContext.Provider
-                      value={{
-                        search,
-                        resultsPage,
-                        resetResultsPage,
-                        totalSearchResults,
-                        totalSearchPages,
-                        handleNextPage,
-                        handlePrevPage,
-                        getAvailabilitySeletion,
-                        availabilityOption,
-                        themeToggler,
-                        theme,
-                        DataContext,
-                        handleFormSubmit,
-                        movies,
-                      }}
+                    <WatchlistContext.Provider
+                      value={{ handleToggleWatchList, watchlist }}
                     >
-                      <Component {...pageProps} />
-                    </DataContext.Provider>
-                  </WatchlistContext.Provider>
-                </CinemaContext.Provider>
-              </TrendingContext.Provider>
-            </WatchedContext.Provider>
-          </MediaContext.Provider>
-        </WatchlistTVContext.Provider>
+                      <DataContext.Provider
+                        value={{
+                          search,
+                          resultsPage,
+                          resetResultsPage,
+                          totalSearchResults,
+                          totalSearchPages,
+                          handleNextPage,
+                          handlePrevPage,
+                          getAvailabilitySeletion,
+                          availabilityOption,
+                          themeToggler,
+                          theme,
+                          DataContext,
+                          handleFormSubmit,
+                          movies,
+                        }}
+                      >
+                        <Component {...pageProps} />
+                      </DataContext.Provider>
+                    </WatchlistContext.Provider>
+                  </CinemaContext.Provider>
+                </TrendingContext.Provider>
+              </WatchedContext.Provider>
+            </MediaContext.Provider>
+          </WatchlistTVContext.Provider>
+        </WatchedTVContext.Provider>
       </ThemeProvider>
     </>
   );

--- a/pages/api/genres.js
+++ b/pages/api/genres.js
@@ -1,5 +1,9 @@
 const genres = [
   {
+    id: 10759,
+    name: "Action & Adventure",
+  },
+  {
     id: 28,
     name: "Action",
   },
@@ -88,7 +92,7 @@ const genres = [
     name: "Reality",
   },
   {
-    id: 10764,
+    id: 10765,
     name: "Sci-Fi & Fantasy",
   },
   {

--- a/pages/api/genres.js
+++ b/pages/api/genres.js
@@ -75,6 +75,34 @@ const genres = [
     id: 37,
     name: "Western",
   },
+  {
+    id: 10762,
+    name: "Kids",
+  },
+  {
+    id: 10763,
+    name: "News",
+  },
+  {
+    id: 10764,
+    name: "Reality",
+  },
+  {
+    id: 10764,
+    name: "Sci-Fi & Fantasy",
+  },
+  {
+    id: 10766,
+    name: "Soap",
+  },
+  {
+    id: 10767,
+    name: "Talk",
+  },
+  {
+    id: 10768,
+    name: "War $ Politics",
+  },
 ];
 
 export default genres;

--- a/pages/index.js
+++ b/pages/index.js
@@ -137,7 +137,7 @@ export default function Home() {
           </p>
         </StyledSectionHeader>
         <StyledSectionForm>
-          <Form onSubmit={handleFormSubmit} movies={movies} />
+          <Form onSubmit={handleFormSubmit} />
         </StyledSectionForm>
         <StyledLine />
         {watchlist.length > 0 ? (

--- a/pages/index.js
+++ b/pages/index.js
@@ -131,9 +131,8 @@ export default function Home() {
               height={25}
             />
           </Link>
-
           <p>
-            Grab your 🍿 and let us watch a <strong>movie!</strong>{" "}
+            Grab your 🍿 and let us watch something <strong>cool!</strong>{" "}
           </p>
         </StyledSectionHeader>
         <StyledSectionForm>

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,8 +37,13 @@ const StyledMoviePick = styled.section`
   margin-top: 40px;
 `;
 
+const StyledNoMoviePickSection = styled.section`
+  display: flex;
+  justify-content: center;
+`;
+
 const StyledNoMoviePick = styled.section`
-  width: 350px;
+  width: 340px;
 `;
 
 const StyledHeader = styled.h4`
@@ -164,14 +169,16 @@ export default function Home() {
             </StyledLink>
           </StyledMoviePick>
         ) : (
-          <StyledNoMoviePick>
-            <h1>You must be fun at parties 😪</h1>
-            <p>
-              Here we WOULD 😒 suggest you random movies from your watchlist to
-              watch.{" "}
-            </p>
-            <p>How about adding some movies?</p>
-          </StyledNoMoviePick>
+          <StyledNoMoviePickSection>
+            <StyledNoMoviePick>
+              <h1>You must be fun at parties 😪</h1>
+              <p>
+                Here we WOULD 😒 suggest you random movies from your watchlist
+                to watch.{" "}
+              </p>
+              <p>How about adding some movies?</p>
+            </StyledNoMoviePick>
+          </StyledNoMoviePickSection>
         )}
         <StyledLine />
         <StyledSectionTrending>

--- a/pages/index.js
+++ b/pages/index.js
@@ -107,8 +107,6 @@ export default function Home() {
   const { dayTrending, trendingMovies, handleTrendingSort } =
     useContext(TrendingContext);
 
-  const [runtime, setRuntime] = useState(0);
-
   const randomMovie = useMemo(
     () => getRandomIndexFromArray(watchlist),
     [watchlist]
@@ -119,25 +117,6 @@ export default function Home() {
   );
 
   const cutTrendingArray = trendingMovies.slice(0, 9);
-
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const response = await fetch(
-          `/api/themoviedb/movie/${movie.id}?&language=eng-US`
-        );
-        if (response.ok) {
-          const data = await response.json();
-          setRuntime(data.runtime);
-        } else {
-          throw new Error("Something went wrong");
-        }
-      } catch (error) {
-        console.log(`Error: ${error.message}`);
-      }
-    }
-    fetchData();
-  }, []);
 
   return (
     <>

--- a/pages/my-watched/[id].js
+++ b/pages/my-watched/[id].js
@@ -1,35 +1,47 @@
 import React from "react";
 import MovieDetail from "../../components/MovieDetail";
 import { useContext } from "react";
-import { WatchedContext } from "../_app";
+import { WatchedContext, WatchedTVContext } from "../_app";
 import { useRouter } from "next/router";
 import PushButton from "../../components/PushButton";
 import MovieDetailFooter from "../../components/MovieDetailFooter";
 import Navigation from "../../components/Navigation";
+import TVDetail from "../../components/TVDetail";
+import TVDetailFooter from "../../components/TVDetailFooter";
 
 export default function MovieDetailPage() {
   const { watched } = useContext(WatchedContext);
+  const { watchedTV } = useContext(WatchedTVContext);
 
   const router = useRouter();
 
-  const currentMovie = watched.find(
-    (movie) => movie.id.toString() === router.query.id
-  );
+  const currentMovie =
+    watched.find((movie) => movie.id.toString() === router.query.id) ||
+    watchedTV.find((movie) => movie.id.toString() === router.query.id);
 
   if (!currentMovie)
     return (
       <main>
         <PushButton />
         <h1>{`We're quite sorry about this!`}</h1>
-        <p>{`The movie id '${router.query.id}' seems to be not in your watched movies.`}</p>
+        <p>{`The movie id '${router.query.id}' seems to be not in your watched.`}</p>
         <Navigation />
       </main>
     );
 
   return (
     <main>
-      <MovieDetail movie={currentMovie} />
-      <MovieDetailFooter movie={currentMovie} />
+      {watched.includes(currentMovie) ? (
+        <>
+          <MovieDetail movie={currentMovie} />
+          <MovieDetailFooter movie={currentMovie} />
+        </>
+      ) : (
+        <>
+          <TVDetail movie={currentMovie} />
+          <TVDetailFooter movie={currentMovie} />
+        </>
+      )}
     </main>
   );
 }

--- a/pages/my-watched/[id].js
+++ b/pages/my-watched/[id].js
@@ -9,7 +9,7 @@ import Navigation from "../../components/Navigation";
 import TVDetail from "../../components/TVDetail";
 import TVDetailFooter from "../../components/TVDetailFooter";
 
-export default function MovieDetailPage() {
+export default function DetailPage() {
   const { watched } = useContext(WatchedContext);
   const { watchedTV } = useContext(WatchedTVContext);
 

--- a/pages/my-watched/index.js
+++ b/pages/my-watched/index.js
@@ -7,16 +7,18 @@ import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
 import TVGrid from "../../components/TVGrid";
 import TV from "../../components/TV";
-import { ListWrapper } from "../../components/Styled Components/ListPage";
-import { ButtonsFlexContainer } from "../../components/Styled Components/ListPage";
-import { ButtonsContainer } from "../../components/Styled Components/ListPage";
-import { LayoutListButton } from "../../components/Styled Components/ListPage";
-import { LayoutGridButton } from "../../components/Styled Components/ListPage";
-import { MediaHeader } from "../../components/Styled Components/ListPage";
-import { ContentContainerGrid } from "../../components/Styled Components/ListPage";
-import { LinkWrapper } from "../../components/Styled Components/ListPage";
-import { EmptyContentContainer } from "../../components/Styled Components/ListPage";
-import { ContentContainerList } from "../../components/Styled Components/ListPage";
+import {
+  ListWrapper,
+  ContentContainerList,
+  EmptyContentContainer,
+  ButtonsFlexContainer,
+  ButtonsContainer,
+  LayoutListButton,
+  LayoutGridButton,
+  MediaHeader,
+  ContentContainerGrid,
+  LinkWrapper,
+} from "../../components/Styled Components/ListPage";
 
 export default function MyWatchedPage() {
   const [listLayoutWatched, setListLayoutWatched] = useLocalStorageState(

--- a/pages/my-watched/index.js
+++ b/pages/my-watched/index.js
@@ -3,85 +3,20 @@ import { useContext } from "react";
 import { WatchedContext, WatchedTVContext, DataContext } from "../_app";
 import Movie from "../../components/Movie";
 import MovieGrid from "../../components/MovieGrid";
-import styled from "styled-components";
-import Link from "next/link";
 import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
 import TVGrid from "../../components/TVGrid";
 import TV from "../../components/TV";
-
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  color: black;
-  cursor: pointer;
-`;
-
-const StyledButtonList = styled.button`
-  border: none;
-  background-color: transparent;
-
-  :enabled {
-    color: ${(props) => props.theme.fontColor};
-  }
-
-  :disabled {
-    color: #f97b7b;
-  }
-`;
-
-const StyledButtonGrid = styled.button`
-  border: none;
-  background-color: transparent;
-
-  :enabled {
-    color: ${(props) => props.theme.fontColor};
-  }
-
-  :disabled {
-    color: #f97b7b;
-  }
-`;
-
-const StyledDiv = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  justify-items: center;
-  grid-row-gap: 5px;
-  margin-top: 15px;
-`;
-
-const StyledSectionEmpty = styled.section`
-  height: 550px;
-  padding-left: 15px;
-  padding-right: 15px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
-
-const StyledSection = styled.section`
-  padding-left: 15px;
-  padding-right: 15px;
-`;
-
-const StyledSectionButtonsFlex = styled.section`
-  width: 100%;
-  margin-bottom: 15px;
-`;
-
-const StyledSectionButtons = styled.section`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const StyledSectionList = styled.section`
-  margin-top: 15px;
-`;
-
-const StyledHeaderMediaType = styled.h5`
-  margin-bottom: 5px;
-`;
+import { ListWrapper } from "../../components/Styled Components/ListPage";
+import { ButtonsFlexContainer } from "../../components/Styled Components/ListPage";
+import { ButtonsContainer } from "../../components/Styled Components/ListPage";
+import { LayoutListButton } from "../../components/Styled Components/ListPage";
+import { LayoutGridButton } from "../../components/Styled Components/ListPage";
+import { MediaHeader } from "../../components/Styled Components/ListPage";
+import { ContentContainerGrid } from "../../components/Styled Components/ListPage";
+import { LinkWrapper } from "../../components/Styled Components/ListPage";
+import { EmptyContentContainer } from "../../components/Styled Components/ListPage";
+import { ContentContainerList } from "../../components/Styled Components/ListPage";
 
 export default function MyWatchedPage() {
   const [listLayoutWatched, setListLayoutWatched] = useLocalStorageState(
@@ -102,21 +37,21 @@ export default function MyWatchedPage() {
   if (watched.length === 0)
     return (
       <main>
-        <StyledSectionEmpty>
+        <EmptyContentContainer>
           <h2>Nothing to 👀 here.</h2>
           <p>Why dont you add some? </p>
-        </StyledSectionEmpty>
+        </EmptyContentContainer>
         <Navigation />
       </main>
     );
 
   return (
     <main>
-      <StyledSection>
+      <ListWrapper>
         <h2>My Watched movies ({watched.length}):</h2>
-        <StyledSectionButtonsFlex>
-          <StyledSectionButtons>
-            <StyledButtonList
+        <ButtonsFlexContainer>
+          <ButtonsContainer>
+            <LayoutListButton
               color={theme}
               onClick={() => {
                 setLayoutType(true);
@@ -124,8 +59,8 @@ export default function MyWatchedPage() {
               disabled={listLayoutWatched ? true : false}
             >
               List
-            </StyledButtonList>
-            <StyledButtonGrid
+            </LayoutListButton>
+            <LayoutGridButton
               color={theme}
               onClick={() => {
                 setLayoutType(false);
@@ -133,58 +68,56 @@ export default function MyWatchedPage() {
               disabled={listLayoutWatched ? false : true}
             >
               Grid
-            </StyledButtonGrid>
-          </StyledSectionButtons>
-        </StyledSectionButtonsFlex>
+            </LayoutGridButton>
+          </ButtonsContainer>
+        </ButtonsFlexContainer>
 
-        <StyledHeaderMediaType>Movies ({watched.length})</StyledHeaderMediaType>
+        <MediaHeader>Movies ({watched.length})</MediaHeader>
 
         {listLayoutWatched ? (
-          <StyledSectionList>
+          <ContentContainerList>
             {watched.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watched/${movie.id}`}>
                   <Movie movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledSectionList>
+          </ContentContainerList>
         ) : (
-          <StyledDiv>
+          <ContentContainerGrid>
             {watched.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watched/${movie.id}`}>
                   <MovieGrid movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledDiv>
+          </ContentContainerGrid>
         )}
-        <StyledHeaderMediaType>
-          Shows ({watchedTV.length})
-        </StyledHeaderMediaType>
+        <MediaHeader>Shows ({watchedTV.length})</MediaHeader>
         {listLayoutWatched ? (
-          <StyledSectionList>
+          <ContentContainerList>
             {watchedTV.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watched/${movie.id}`}>
                   <TV movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledSectionList>
+          </ContentContainerList>
         ) : (
-          <StyledDiv>
+          <ContentContainerGrid>
             {watchedTV.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watched/${movie.id}`}>
                   <TVGrid movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledDiv>
+          </ContentContainerGrid>
         )}
-      </StyledSection>
+      </ListWrapper>
       <Navigation />
     </main>
   );

--- a/pages/my-watched/index.js
+++ b/pages/my-watched/index.js
@@ -48,6 +48,16 @@ const StyledDiv = styled.div`
   margin-top: 15px;
 `;
 
+const StyledSectionEmpty = styled.section`
+  height: 550px;
+  padding-left: 15px;
+  padding-right: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
 const StyledSection = styled.section`
   padding-left: 15px;
   padding-right: 15px;
@@ -84,8 +94,10 @@ export default function MyWatchedPage() {
   if (watched.length === 0)
     return (
       <main>
-        <h2>Nothing to 👀 here.</h2>
-        <p>Why dont you add some? </p>
+        <StyledSectionEmpty>
+          <h2>Nothing to 👀 here.</h2>
+          <p>Why dont you add some? </p>
+        </StyledSectionEmpty>
         <Navigation />
       </main>
     );

--- a/pages/my-watched/index.js
+++ b/pages/my-watched/index.js
@@ -1,12 +1,14 @@
 import React from "react";
 import { useContext } from "react";
-import { WatchedContext, DataContext } from "../_app";
+import { WatchedContext, WatchedTVContext, DataContext } from "../_app";
 import Movie from "../../components/Movie";
 import MovieGrid from "../../components/MovieGrid";
 import styled from "styled-components";
 import Link from "next/link";
 import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
+import TVGrid from "../../components/TVGrid";
+import TV from "../../components/TV";
 
 const StyledLink = styled(Link)`
   text-decoration: none;
@@ -77,6 +79,10 @@ const StyledSectionList = styled.section`
   margin-top: 15px;
 `;
 
+const StyledHeaderMediaType = styled.h5`
+  margin-bottom: 5px;
+`;
+
 export default function MyWatchedPage() {
   const [listLayoutWatched, setListLayoutWatched] = useLocalStorageState(
     "newLayoutWatched",
@@ -85,6 +91,8 @@ export default function MyWatchedPage() {
     }
   );
   const { watched } = useContext(WatchedContext);
+  const { watchedTV } = useContext(WatchedTVContext);
+
   const { theme } = useContext(DataContext);
 
   function setLayoutType(boolean) {
@@ -128,6 +136,9 @@ export default function MyWatchedPage() {
             </StyledButtonGrid>
           </StyledSectionButtons>
         </StyledSectionButtonsFlex>
+
+        <StyledHeaderMediaType>Movies ({watched.length})</StyledHeaderMediaType>
+
         {listLayoutWatched ? (
           <StyledSectionList>
             {watched.map((movie) => {
@@ -144,6 +155,30 @@ export default function MyWatchedPage() {
               return (
                 <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
                   <MovieGrid movie={movie} />
+                </StyledLink>
+              );
+            })}
+          </StyledDiv>
+        )}
+        <StyledHeaderMediaType>
+          Shows ({watchedTV.length})
+        </StyledHeaderMediaType>
+        {listLayoutWatched ? (
+          <StyledSectionList>
+            {watchedTV.map((movie) => {
+              return (
+                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                  <TV movie={movie} />
+                </StyledLink>
+              );
+            })}
+          </StyledSectionList>
+        ) : (
+          <StyledDiv>
+            {watchedTV.map((movie) => {
+              return (
+                <StyledLink key={movie.id} href={`my-watched/${movie.id}`}>
+                  <TVGrid movie={movie} />
                 </StyledLink>
               );
             })}

--- a/pages/my-watchlist/[id].js
+++ b/pages/my-watchlist/[id].js
@@ -9,7 +9,7 @@ import Navigation from "../../components/Navigation";
 import TVDetail from "../../components/TVDetail";
 import TVDetailFooter from "../../components/TVDetailFooter";
 
-export default function MovieDetailPage() {
+export default function DetailPage() {
   const { watchlist } = useContext(WatchlistContext);
   const { watchlistTV } = useContext(WatchlistTVContext);
 

--- a/pages/my-watchlist/[id].js
+++ b/pages/my-watchlist/[id].js
@@ -1,20 +1,27 @@
 import React from "react";
 import MovieDetail from "../../components/MovieDetail";
 import { useContext } from "react";
-import { WatchlistContext } from "../_app";
+import { WatchlistContext, WatchlistTVContext } from "../_app";
 import { useRouter } from "next/router";
 import PushButton from "../../components/PushButton";
 import MovieDetailFooter from "../../components/MovieDetailFooter";
 import Navigation from "../../components/Navigation";
+import TVDetail from "../../components/TVDetail";
+import TVDetailFooter from "../../components/TVDetailFooter";
 
 export default function MovieDetailPage() {
   const { watchlist } = useContext(WatchlistContext);
+  const { watchlistTV } = useContext(WatchlistTVContext);
 
   const router = useRouter();
 
-  const currentMovie = watchlist.find(
+  /*  const currentMovie = watchlist.find(
     (movie) => movie.id.toString() === router.query.id
-  );
+  ); */
+
+  const currentMovie =
+    watchlist.find((movie) => movie.id.toString() === router.query.id) ||
+    watchlistTV.find((movie) => movie.id.toString() === router.query.id);
 
   if (!currentMovie)
     return (
@@ -28,8 +35,17 @@ export default function MovieDetailPage() {
 
   return (
     <main>
-      <MovieDetail movie={currentMovie} />
-      <MovieDetailFooter movie={currentMovie} />
+      {watchlist.includes(currentMovie) ? (
+        <>
+          <MovieDetail movie={currentMovie} />
+          <MovieDetailFooter movie={currentMovie} />
+        </>
+      ) : (
+        <>
+          <TVDetail movie={currentMovie} />
+          <TVDetailFooter movie={currentMovie} />
+        </>
+      )}
     </main>
   );
 }

--- a/pages/my-watchlist/[id].js
+++ b/pages/my-watchlist/[id].js
@@ -15,10 +15,6 @@ export default function MovieDetailPage() {
 
   const router = useRouter();
 
-  /*  const currentMovie = watchlist.find(
-    (movie) => movie.id.toString() === router.query.id
-  ); */
-
   const currentMovie =
     watchlist.find((movie) => movie.id.toString() === router.query.id) ||
     watchlistTV.find((movie) => movie.id.toString() === router.query.id);

--- a/pages/my-watchlist/index.js
+++ b/pages/my-watchlist/index.js
@@ -7,16 +7,18 @@ import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
 import TVGrid from "../../components/TVGrid";
 import TV from "../../components/TV";
-import { ListWrapper } from "../../components/Styled Components/ListPage";
-import { ButtonsFlexContainer } from "../../components/Styled Components/ListPage";
-import { ButtonsContainer } from "../../components/Styled Components/ListPage";
-import { LayoutListButton } from "../../components/Styled Components/ListPage";
-import { LayoutGridButton } from "../../components/Styled Components/ListPage";
-import { MediaHeader } from "../../components/Styled Components/ListPage";
-import { ContentContainerGrid } from "../../components/Styled Components/ListPage";
-import { LinkWrapper } from "../../components/Styled Components/ListPage";
-import { EmptyContentContainer } from "../../components/Styled Components/ListPage";
-import { ContentContainerList } from "../../components/Styled Components/ListPage";
+import {
+  ListWrapper,
+  ContentContainerList,
+  EmptyContentContainer,
+  ButtonsFlexContainer,
+  ButtonsContainer,
+  LayoutListButton,
+  LayoutGridButton,
+  MediaHeader,
+  ContentContainerGrid,
+  LinkWrapper,
+} from "../../components/Styled Components/ListPage";
 
 export default function MyWatchlistPage() {
   const [listLayoutWatchlist, setListLayoutWatchlist] = useLocalStorageState(

--- a/pages/my-watchlist/index.js
+++ b/pages/my-watchlist/index.js
@@ -1,12 +1,14 @@
 import React from "react";
 import { useContext } from "react";
-import { WatchlistContext, DataContext } from "../_app";
+import { WatchlistContext, WatchlistTVContext, DataContext } from "../_app";
 import Movie from "../../components/Movie";
 import MovieGrid from "../../components/MovieGrid";
 import styled from "styled-components";
 import Link from "next/link";
 import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
+import TVGrid from "../../components/TVGrid";
+import TV from "../../components/TV";
 
 const StyledLink = styled(Link)`
   text-decoration: none;
@@ -77,6 +79,10 @@ const StyledSectionList = styled.section`
   margin-top: 15px;
 `;
 
+const StyledHeaderMediaType = styled.h5`
+  margin-bottom: 5px;
+`;
+
 export default function MyWatchlistPage() {
   const [listLayoutWatchlist, setListLayoutWatchlist] = useLocalStorageState(
     "newLayoutWatchlist",
@@ -85,6 +91,8 @@ export default function MyWatchlistPage() {
     }
   );
   const { watchlist } = useContext(WatchlistContext);
+  const { watchlistTV } = useContext(WatchlistTVContext);
+
   const { theme } = useContext(DataContext);
 
   function setLayoutType(boolean) {
@@ -105,7 +113,7 @@ export default function MyWatchlistPage() {
   return (
     <main>
       <StyledSection>
-        <h2>My Watchlist ({watchlist.length}):</h2>
+        <h2>My Watchlist:</h2>
         <StyledSectionButtonsFlex>
           <StyledSectionButtons>
             <StyledButtonList
@@ -128,6 +136,11 @@ export default function MyWatchlistPage() {
             </StyledButtonGrid>
           </StyledSectionButtons>
         </StyledSectionButtonsFlex>
+
+        <StyledHeaderMediaType>
+          Movies ({watchlist.length})
+        </StyledHeaderMediaType>
+
         {listLayoutWatchlist ? (
           <StyledSectionList>
             {watchlist.map((movie) => {
@@ -144,6 +157,32 @@ export default function MyWatchlistPage() {
               return (
                 <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
                   <MovieGrid movie={movie} />
+                </StyledLink>
+              );
+            })}
+          </StyledDiv>
+        )}
+
+        <StyledHeaderMediaType>
+          Shows ({watchlistTV.length})
+        </StyledHeaderMediaType>
+
+        {listLayoutWatchlist ? (
+          <StyledSectionList>
+            {watchlistTV.map((movie) => {
+              return (
+                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                  <TV movie={movie} />
+                </StyledLink>
+              );
+            })}
+          </StyledSectionList>
+        ) : (
+          <StyledDiv>
+            {watchlistTV.map((movie) => {
+              return (
+                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                  <TVGrid movie={movie} />
                 </StyledLink>
               );
             })}

--- a/pages/my-watchlist/index.js
+++ b/pages/my-watchlist/index.js
@@ -3,85 +3,20 @@ import { useContext } from "react";
 import { WatchlistContext, WatchlistTVContext, DataContext } from "../_app";
 import Movie from "../../components/Movie";
 import MovieGrid from "../../components/MovieGrid";
-import styled from "styled-components";
-import Link from "next/link";
 import Navigation from "../../components/Navigation";
 import useLocalStorageState from "use-local-storage-state";
 import TVGrid from "../../components/TVGrid";
 import TV from "../../components/TV";
-
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  color: black;
-  cursor: pointer;
-`;
-
-const StyledButtonList = styled.button`
-  border: none;
-  background-color: transparent;
-
-  :enabled {
-    color: ${(props) => props.theme.fontColor};
-  }
-
-  :disabled {
-    color: #f97b7b;
-  }
-`;
-
-const StyledButtonGrid = styled.button`
-  border: none;
-  background-color: transparent;
-
-  :enabled {
-    color: ${(props) => props.theme.fontColor};
-  }
-
-  :disabled {
-    color: #f97b7b;
-  }
-`;
-
-const StyledDiv = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  justify-items: center;
-  grid-row-gap: 5px;
-  margin-top: 15px;
-`;
-
-const StyledSection = styled.section`
-  padding-left: 15px;
-  padding-right: 15px;
-`;
-
-const StyledSectionEmpty = styled.section`
-  height: 550px;
-  padding-left: 15px;
-  padding-right: 15px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
-
-const StyledSectionButtonsFlex = styled.section`
-  width: 100%;
-  margin-bottom: 15px;
-`;
-
-const StyledSectionButtons = styled.section`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const StyledSectionList = styled.section`
-  margin-top: 15px;
-`;
-
-const StyledHeaderMediaType = styled.h5`
-  margin-bottom: 5px;
-`;
+import { ListWrapper } from "../../components/Styled Components/ListPage";
+import { ButtonsFlexContainer } from "../../components/Styled Components/ListPage";
+import { ButtonsContainer } from "../../components/Styled Components/ListPage";
+import { LayoutListButton } from "../../components/Styled Components/ListPage";
+import { LayoutGridButton } from "../../components/Styled Components/ListPage";
+import { MediaHeader } from "../../components/Styled Components/ListPage";
+import { ContentContainerGrid } from "../../components/Styled Components/ListPage";
+import { LinkWrapper } from "../../components/Styled Components/ListPage";
+import { EmptyContentContainer } from "../../components/Styled Components/ListPage";
+import { ContentContainerList } from "../../components/Styled Components/ListPage";
 
 export default function MyWatchlistPage() {
   const [listLayoutWatchlist, setListLayoutWatchlist] = useLocalStorageState(
@@ -102,21 +37,21 @@ export default function MyWatchlistPage() {
   if (watchlist.length === 0)
     return (
       <main>
-        <StyledSectionEmpty>
+        <EmptyContentContainer>
           <h2>Nothing to 👀 here.</h2>
           <p>Why dont you add some? </p>
-        </StyledSectionEmpty>
+        </EmptyContentContainer>
         <Navigation />
       </main>
     );
 
   return (
     <main>
-      <StyledSection>
+      <ListWrapper>
         <h2>My Watchlist:</h2>
-        <StyledSectionButtonsFlex>
-          <StyledSectionButtons>
-            <StyledButtonList
+        <ButtonsFlexContainer>
+          <ButtonsContainer>
+            <LayoutListButton
               color={theme}
               onClick={() => {
                 setLayoutType(true);
@@ -124,8 +59,8 @@ export default function MyWatchlistPage() {
               disabled={listLayoutWatchlist ? true : false}
             >
               List
-            </StyledButtonList>
-            <StyledButtonGrid
+            </LayoutListButton>
+            <LayoutGridButton
               color={theme}
               onClick={() => {
                 setLayoutType(false);
@@ -133,62 +68,58 @@ export default function MyWatchlistPage() {
               disabled={listLayoutWatchlist ? false : true}
             >
               Grid
-            </StyledButtonGrid>
-          </StyledSectionButtons>
-        </StyledSectionButtonsFlex>
+            </LayoutGridButton>
+          </ButtonsContainer>
+        </ButtonsFlexContainer>
 
-        <StyledHeaderMediaType>
-          Movies ({watchlist.length})
-        </StyledHeaderMediaType>
+        <MediaHeader>Movies ({watchlist.length})</MediaHeader>
 
         {listLayoutWatchlist ? (
-          <StyledSectionList>
+          <ContentContainerList>
             {watchlist.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watchlist/${movie.id}`}>
                   <Movie movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledSectionList>
+          </ContentContainerList>
         ) : (
-          <StyledDiv>
+          <ContentContainerGrid>
             {watchlist.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watchlist/${movie.id}`}>
                   <MovieGrid movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledDiv>
+          </ContentContainerGrid>
         )}
 
-        <StyledHeaderMediaType>
-          Shows ({watchlistTV.length})
-        </StyledHeaderMediaType>
+        <MediaHeader>Shows ({watchlistTV.length})</MediaHeader>
 
         {listLayoutWatchlist ? (
-          <StyledSectionList>
+          <ContentContainerList>
             {watchlistTV.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watchlist/${movie.id}`}>
                   <TV movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledSectionList>
+          </ContentContainerList>
         ) : (
-          <StyledDiv>
+          <ContentContainerGrid>
             {watchlistTV.map((movie) => {
               return (
-                <StyledLink key={movie.id} href={`my-watchlist/${movie.id}`}>
+                <LinkWrapper key={movie.id} href={`my-watchlist/${movie.id}`}>
                   <TVGrid movie={movie} />
-                </StyledLink>
+                </LinkWrapper>
               );
             })}
-          </StyledDiv>
+          </ContentContainerGrid>
         )}
-      </StyledSection>
+      </ListWrapper>
       <Navigation />
     </main>
   );

--- a/pages/my-watchlist/index.js
+++ b/pages/my-watchlist/index.js
@@ -53,6 +53,16 @@ const StyledSection = styled.section`
   padding-right: 15px;
 `;
 
+const StyledSectionEmpty = styled.section`
+  height: 550px;
+  padding-left: 15px;
+  padding-right: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
 const StyledSectionButtonsFlex = styled.section`
   width: 100%;
   margin-bottom: 15px;
@@ -84,8 +94,10 @@ export default function MyWatchlistPage() {
   if (watchlist.length === 0)
     return (
       <main>
-        <h2>Nothing to 👀 here.</h2>
-        <p>Why dont you add some? </p>
+        <StyledSectionEmpty>
+          <h2>Nothing to 👀 here.</h2>
+          <p>Why dont you add some? </p>
+        </StyledSectionEmpty>
         <Navigation />
       </main>
     );

--- a/pages/search-results/[id].js
+++ b/pages/search-results/[id].js
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import BackButton from "../../components/PushButton";
 import MovieDetailFooter from "../../components/MovieDetailFooter";
 import Navigation from "../../components/Navigation";
+import TVDetail from "../../components/TVDetail";
 
 export default function MovieDetailPage() {
   const { movies } = useContext(DataContext);
@@ -35,7 +36,7 @@ export default function MovieDetailPage() {
           <MovieDetailFooter movie={currentMovie} />{" "}
         </>
       ) : (
-        <MovieDetail movie={currentMovie} />
+        <TVDetail movie={currentMovie} />
       )}
     </main>
   );

--- a/pages/search-results/[id].js
+++ b/pages/search-results/[id].js
@@ -1,7 +1,7 @@
 import React from "react";
 import MovieDetail from "../../components/MovieDetail";
 import { useContext } from "react";
-import { DataContext } from "../_app";
+import { DataContext, MediaContext } from "../_app";
 import { useRouter } from "next/router";
 import BackButton from "../../components/PushButton";
 import MovieDetailFooter from "../../components/MovieDetailFooter";
@@ -9,6 +9,7 @@ import Navigation from "../../components/Navigation";
 
 export default function MovieDetailPage() {
   const { movies } = useContext(DataContext);
+  const { mediaTypeMovies } = useContext(MediaContext);
 
   const router = useRouter();
 
@@ -28,8 +29,14 @@ export default function MovieDetailPage() {
 
   return (
     <main>
-      <MovieDetail movie={currentMovie} />
-      <MovieDetailFooter movie={currentMovie} />
+      {mediaTypeMovies === "movie" ? (
+        <>
+          <MovieDetail movie={currentMovie} />
+          <MovieDetailFooter movie={currentMovie} />{" "}
+        </>
+      ) : (
+        <MovieDetail movie={currentMovie} />
+      )}
     </main>
   );
 }

--- a/pages/search-results/[id].js
+++ b/pages/search-results/[id].js
@@ -7,6 +7,7 @@ import BackButton from "../../components/PushButton";
 import MovieDetailFooter from "../../components/MovieDetailFooter";
 import Navigation from "../../components/Navigation";
 import TVDetail from "../../components/TVDetail";
+import TVDetailFooter from "../../components/TVDetailFooter";
 
 export default function MovieDetailPage() {
   const { movies } = useContext(DataContext);
@@ -33,10 +34,13 @@ export default function MovieDetailPage() {
       {mediaTypeMovies === "movie" ? (
         <>
           <MovieDetail movie={currentMovie} />
-          <MovieDetailFooter movie={currentMovie} />{" "}
+          <MovieDetailFooter movie={currentMovie} />
         </>
       ) : (
-        <TVDetail movie={currentMovie} />
+        <>
+          <TVDetail movie={currentMovie} />
+          <TVDetailFooter movie={currentMovie} />
+        </>
       )}
     </main>
   );

--- a/pages/search-results/index.js
+++ b/pages/search-results/index.js
@@ -88,7 +88,8 @@ export default function SearchResultsPage() {
       </StyledSectionButtons>
       {movies?.map((movie) => (
         <StyledLink key={movie.id} href={`search-results/${movie.id}`}>
-          <Movie movie={movie} />
+          {/* <Movie movie={movie} /> */}
+          <p>hey</p>
         </StyledLink>
       ))}
       <StyledSectionButtons>

--- a/pages/search-results/index.js
+++ b/pages/search-results/index.js
@@ -6,17 +6,7 @@ import Link from "next/link";
 import styled from "styled-components";
 import Navigation from "../../components/Navigation";
 import TV from "../../components/TV";
-
-const StyledSectionEmpty = styled.section`
-  height: 550px;
-  padding-left: 15px;
-  padding-right: 15px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-`;
+import { EmptyContentContainer } from "../../components/Styled Components/ListPage";
 
 const StyledHeader = styled.h2`
   margin-left: 15px;
@@ -71,12 +61,12 @@ export default function SearchResultsPage() {
     return (
       <>
         <PushButton />
-        <StyledSectionEmpty>
+        <EmptyContentContainer>
           <h2>Whoops, something seems wrong</h2>
           <p>{`The movie '${search}' doesn't seem to exist`}</p>
           <p>{`Please try to go back and search again :)`}</p>
           <Navigation />
-        </StyledSectionEmpty>
+        </EmptyContentContainer>
       </>
     );
 

--- a/pages/search-results/index.js
+++ b/pages/search-results/index.js
@@ -7,6 +7,17 @@ import styled from "styled-components";
 import Navigation from "../../components/Navigation";
 import TV from "../../components/TV";
 
+const StyledSectionEmpty = styled.section`
+  height: 550px;
+  padding-left: 15px;
+  padding-right: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+`;
+
 const StyledHeader = styled.h2`
   margin-left: 15px;
 `;
@@ -60,10 +71,12 @@ export default function SearchResultsPage() {
     return (
       <>
         <PushButton />
-        <h2>Whoops, something seems wrong</h2>
-        <p>{`The movie '${search}' doesn't seem to exist`}</p>
-        <p>{`Please try to go back and search again :)`}</p>
-        <Navigation />
+        <StyledSectionEmpty>
+          <h2>Whoops, something seems wrong</h2>
+          <p>{`The movie '${search}' doesn't seem to exist`}</p>
+          <p>{`Please try to go back and search again :)`}</p>
+          <Navigation />
+        </StyledSectionEmpty>
       </>
     );
 

--- a/pages/search-results/index.js
+++ b/pages/search-results/index.js
@@ -5,6 +5,7 @@ import { DataContext } from "../_app";
 import Link from "next/link";
 import styled from "styled-components";
 import Navigation from "../../components/Navigation";
+import TV from "../../components/TV";
 
 const StyledHeader = styled.h2`
   margin-left: 15px;
@@ -89,7 +90,7 @@ export default function SearchResultsPage() {
       {movies?.map((movie) => (
         <StyledLink key={movie.id} href={`search-results/${movie.id}`}>
           {/* <Movie movie={movie} /> */}
-          <p>hey</p>
+          <TV movie={movie} />
         </StyledLink>
       ))}
       <StyledSectionButtons>

--- a/pages/search-results/index.js
+++ b/pages/search-results/index.js
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import Movie from "../../components/Movie";
 import PushButton from "../../components/PushButton";
-import { DataContext } from "../_app";
+import { DataContext, MediaContext } from "../_app";
 import Link from "next/link";
 import styled from "styled-components";
 import Navigation from "../../components/Navigation";
@@ -54,6 +54,7 @@ export default function SearchResultsPage() {
     totalSearchResults,
     theme,
   } = useContext(DataContext);
+  const { mediaTypeMovies } = useContext(MediaContext);
 
   if (movies?.length === 0)
     return (
@@ -89,8 +90,11 @@ export default function SearchResultsPage() {
       </StyledSectionButtons>
       {movies?.map((movie) => (
         <StyledLink key={movie.id} href={`search-results/${movie.id}`}>
-          {/* <Movie movie={movie} /> */}
-          <TV movie={movie} />
+          {mediaTypeMovies === "movie" ? (
+            <Movie movie={movie} />
+          ) : (
+            <TV movie={movie} />
+          )}
         </StyledLink>
       ))}
       <StyledSectionButtons>

--- a/utils/getGenreFrom.js
+++ b/utils/getGenreFrom.js
@@ -7,7 +7,7 @@ export default function getGenreFrom(movie) {
       ", " +
       findGenre(movie?.genre_ids[1])?.name
     );
-  } else if (!movie?.genre_ids[1]) {
+  } else if (movie?.genre_ids[0]) {
     return findGenre(movie?.genre_ids[0])?.name;
   } else {
     return "Missing, Genre";

--- a/utils/getGenreFrom.js
+++ b/utils/getGenreFrom.js
@@ -3,12 +3,12 @@ import findGenre from "./findGenre";
 export default function getGenreFrom(movie) {
   if (movie?.genre_ids[1]) {
     return (
-      findGenre(movie.genre_ids[0]).name +
+      findGenre(movie?.genre_ids[0])?.name +
       ", " +
-      findGenre(movie.genre_ids[1]).name
+      findGenre(movie?.genre_ids[1])?.name
     );
-  } else if (movie?.genre_ids[0]) {
-    return findGenre(movie.genre_ids[0]).name;
+  } else if (!movie?.genre_ids[1]) {
+    return findGenre(movie.genre_ids[0])?.name;
   } else {
     return "Missing, Genre";
   }

--- a/utils/getGenreFrom.js
+++ b/utils/getGenreFrom.js
@@ -8,7 +8,7 @@ export default function getGenreFrom(movie) {
       findGenre(movie?.genre_ids[1])?.name
     );
   } else if (!movie?.genre_ids[1]) {
-    return findGenre(movie.genre_ids[0])?.name;
+    return findGenre(movie?.genre_ids[0])?.name;
   } else {
     return "Missing, Genre";
   }


### PR DESCRIPTION
Add two `radio` inputs to the `form`.
Create new `useState`which tracks `onChange`if movies or shows is selected.
Make the selection `required`.
Make the `useState`global and provide it through `useContext`.
Adapt the initial fetch to change depending of `useState` from movies to shows.
Create `TV` and `TVDetail` Component to display search results with new objects since show and movie objects are not completly identical.
Still use the same routes just adapt thgem with conditional rendering.
Create `TVDetailFooter` and also `useStorageStorageState` for a seperate watchlist and watched for shows.
Use the new footer to adapt the button functions to save the show to the newly created lists.
Append the show lists under the movie lists on the pages.
Adapt the logic so that next.js know with a click if movie/show needs to be displayed.